### PR TITLE
feat(engine): InputCommand abstraction, keyboard event loop, and apply_command

### DIFF
--- a/.workflow/BUGS.md
+++ b/.workflow/BUGS.md
@@ -37,3 +37,48 @@ debug = false
 Or define a dedicated `firmware-release` profile later and document that firmware release builds use `--profile firmware-release`. Either approach keeps the engine's `debug = 2` (useful for profiling) while producing a lean firmware image.
 
 ---
+
+## BUG-002 — [WARNING] `add_nanos_signed` drops `tv_sec` borrow on negative swing overflow
+
+- **File:** `engine/src/clock.rs`, lines 114–124
+- **Branch:** `clock-thread`
+- **Discovered:** 2026-05-02 by code-reviewer agent (step4-clock-thread review)
+- **Severity:** warning
+
+### Description
+
+`add_nanos_signed` adds the signed offset only to `tv_nsec` and then clamps the result to zero when it goes negative. The clamp discards the needed borrow from `tv_sec`. When a negative swing offset is larger than the current `tv_nsec` value (i.e. the swing crosses a whole-second boundary), the resulting `tv_sec` is left unchanged while `tv_nsec` is clamped to 0. This means the absolute wake time becomes `ts.tv_sec + 0.0s` instead of the correct `(ts.tv_sec - 1) + (1.0 - |delta|)s`.
+
+In practice: at 120 BPM sixteenth steps (tick = 125 ms) with swing = -50, the offset is -62.5 ms. If `tv_nsec` at the start of a second is below 62,500,000 ns the wake time gets pinned to the start of the current second rather than 62.5 ms before the beat — causing up to a ~62 ms timing error. `clock_nanosleep(TIMER_ABSTIME)` with a time in the past returns immediately, so the odd step fires too early rather than hanging.
+
+The existing test (`add_nanos_signed_clamps_to_zero`) only asserts `tv_nsec >= 0` and does not catch the incorrect `tv_sec`.
+
+### Reproduction
+
+```rust
+let ts = libc::timespec { tv_sec: 1, tv_nsec: 100_000_000 }; // 1.1 s
+let result = add_nanos_signed(ts, -200_000_000);              // offset -0.2 s
+// Expected: tv_sec=0, tv_nsec=900_000_000 (= 0.9 s)
+// Actual:   tv_sec=1, tv_nsec=0           (= 1.0 s) — 100 ms wrong
+assert_eq!(result.tv_sec, 0);            // FAILS
+assert_eq!(result.tv_nsec, 900_000_000); // FAILS
+```
+
+### Suggested Fix
+
+Perform the arithmetic in full nanoseconds spanning both fields, then re-normalise:
+
+```rust
+fn add_nanos_signed(ts: libc::timespec, nanos: i64) -> libc::timespec {
+    let total_ns: i64 = ts.tv_sec as i64 * 1_000_000_000 + ts.tv_nsec + nanos;
+    let total_ns = total_ns.max(0);
+    libc::timespec {
+        tv_sec: (total_ns / 1_000_000_000) as libc::time_t,
+        tv_nsec: (total_ns % 1_000_000_000) as libc::c_long,
+    }
+}
+```
+
+Also update the existing test to assert the corrected `tv_sec` value alongside `tv_nsec`.
+
+---

--- a/.workflow/BUGS.md
+++ b/.workflow/BUGS.md
@@ -82,3 +82,43 @@ fn add_nanos_signed(ts: libc::timespec, nanos: i64) -> libc::timespec {
 Also update the existing test to assert the corrected `tv_sec` value alongside `tv_nsec`.
 
 ---
+
+## BUG-003 — [WARNING] `.cargo/config.toml` hardcodes `/tmp` paths that break builds on clean systems
+
+- **File:** `.cargo/config.toml`, lines 11 and 17
+- **Branch:** `engine-phase1/midi-output`
+- **Discovered:** 2026-05-02 by code-reviewer agent (step5-midi-output review)
+- **Severity:** warning
+
+### Description
+
+`PKG_CONFIG_PATH = "/tmp/alsa-pkg"` and `rustflags = ["-L", "/tmp/alsa-lib"]` are unconditional entries in the workspace `.cargo/config.toml`. These are host-specific workarounds for a system missing `alsa-lib-devel` that were committed to source. On any other system (CI, another developer's machine, a container with `alsa-lib-devel` properly installed):
+
+- `/tmp/alsa-pkg` will not exist — `pkg-config` will use an empty extra search path (harmless but noisy).
+- `/tmp/alsa-lib` will not exist — the linker receives a spurious `-L /tmp/alsa-lib` flag. If the directory does not exist the linker ignores it; if it exists and contains a stale symlink the build may silently link the wrong `libasound.so`.
+- Any CI system that installs `alsa-lib-devel` normally will have `alsa.pc` in its default `PKG_CONFIG_PATH` already; the `/tmp/alsa-pkg` override is benign only if the override path is missing, but it creates confusion.
+
+The real risk is a developer on a system where `/tmp/alsa-lib` happens to contain something gets a build that links against an unexpected library version.
+
+### Reproduction
+
+1. Checkout `engine-phase1/midi-output` on a system with `alsa-lib-devel` installed.
+2. Run `cargo build -p engine --verbose`.
+3. Observe `-L /tmp/alsa-lib` in the linker invocation regardless of whether that path is meaningful on the current host.
+
+### Suggested Fix
+
+Remove the `[env]` `PKG_CONFIG_PATH` and `[target.x86_64-unknown-linux-gnu]` `rustflags` entries from `.cargo/config.toml`. Document the workaround in a comment in `engine/src/midi_out.rs` or in build notes. Developers needing the workaround can set variables in their shell or in a gitignored local override file:
+
+```toml
+# .cargo/config.local.toml  (gitignored)
+[env]
+PKG_CONFIG_PATH = "/tmp/alsa-pkg"
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-L", "/tmp/alsa-lib"]
+```
+
+Add `.cargo/config.local.toml` to `.gitignore` and document this pattern in the build notes.
+
+---

--- a/.workflow/plans/clock-thread.md
+++ b/.workflow/plans/clock-thread.md
@@ -1,0 +1,49 @@
+# Plan: Clock Thread (step4)
+
+## Overview
+
+Implement `engine/src/clock.rs` — the real-time tick loop that drives the sequencer.
+Uses `libc::clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME)` for drift-free timing.
+Sends `MidiEvent` values over a `SyncSender` for the MIDI output thread.
+
+## Steps
+
+### Step 1: Copy prerequisite files
+
+- Copy `state.rs` and `sequencer.rs` from the sequencer worktree into the clock-thread worktree.
+- Update `lib.rs` to declare all modules including `clock`.
+
+### Step 2: Implement `clock.rs`
+
+Files to create:
+- `engine/src/clock.rs`
+
+Key logic:
+- `run_clock(state, midi_tx)` runs in its own thread.
+- At start, try `libc::sched_setscheduler(0, SCHED_FIFO, priority=50)`; log warning on failure.
+- Get initial absolute time via `clock_gettime(CLOCK_MONOTONIC)`.
+- Loop:
+  1. Read `state` (read lock): get `tempo_bpm`, `step_size`, `swing`, `playing`.
+  2. Compute `tick_nanos = 60_000_000_000 / (bpm as u64 * steps_per_beat)`.
+  3. Compute `swing_offset_nanos = swing as i64 * tick_nanos as i64 / 100`.
+  4. Determine wake time: even step → `next_abs`, odd step → `next_abs + swing_offset`.
+  5. Sleep via `clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &wake_time)`.
+  6. If not playing, advance `next_abs` by `tick_nanos` and continue.
+  7. Acquire write lock, call `state.tick()`, release immediately.
+  8. If `Some(NoteOn { .. })`, set `duration_nanos = tick_nanos`, send on `midi_tx`.
+  9. If `midi_tx.send()` returns `Err`, break (channel disconnected).
+  10. Increment step counter (for swing even/odd determination), advance `next_abs`.
+
+### Step 3: Unit tests (no actual sleep)
+
+In `clock.rs` `#[cfg(test)]` module:
+- Test tick_nanos formula for 120 BPM / Sixteenth = 31_250_000 ns.
+- Test tick_nanos formula for 120 BPM / Quarter = 500_000_000 ns.
+- Test swing_offset math: swing=50, tick_nanos=1_000_000 → offset=500_000.
+- Test swing_offset negative: swing=-25, tick_nanos=1_000_000 → offset=-250_000.
+- Test playhead wraps at 32 ticks using SequencerState directly (no sleep).
+
+### Step 4: Verify
+
+- `cargo test -p engine` passes.
+- `cargo build -p engine --release` succeeds.

--- a/.workflow/plans/midi-output.md
+++ b/.workflow/plans/midi-output.md
@@ -1,0 +1,52 @@
+# Plan: MIDI Output (Step 5)
+
+## Overview
+
+Implement `engine/src/midi_out.rs` — a thread function that receives `MidiEvent`
+values from a channel and dispatches them as raw MIDI bytes via `midir` over ALSA.
+Note-off scheduling is owned here: on NoteOn, send immediately, then spawn a
+short-lived thread that sleeps `duration_nanos` and sends NoteOff.
+
+All MIDI messages are fixed-size stack arrays. No heap on the send path.
+
+## Steps
+
+### Step 1: Update lib.rs to declare state, sequencer, and midi_out modules
+
+Files: `engine/src/lib.rs`
+
+- Add `pub mod state;`, `pub mod sequencer;`, `pub mod midi_out;`
+
+### Step 2: Implement midi_out.rs
+
+Files: `engine/src/midi_out.rs`
+
+- `pub fn run_midi_out(rx: Receiver<MidiEvent>)`
+- Open first available ALSA MIDI output port via midir
+- Log port name on success; log error and return if no ports
+- Loop on `rx.recv()`:
+  - `NoteOn`: send `[0x90|ch, note, vel]` immediately; clone connection, spawn thread sleeping `duration_nanos`, send `[0x80|ch, note, 0]`
+  - `NoteOff`: send `[0x80|ch, note, 0]`
+  - `Start`: send `[0xFA]`
+  - `Stop`: send `[0xFC]`
+  - `Continue`: send `[0xFB]`
+  - `Err(_)` from recv: break (sender dropped)
+
+### Step 3: Unit tests (trait-based mock)
+
+Files: `engine/src/midi_out.rs` (test module) or separate test file
+
+- Define `MidiSender` trait with `send(&mut self, data: &[u8])` and `try_clone(&self)`
+- Implement with a `VecSender` that collects bytes for assertions
+- Test all five event types produce correct byte sequences
+- Test NoteOff thread is spawned correctly (via sleep + mock)
+
+### Step 4: Cargo.toml update
+
+- Ensure `midir = "0.11"` is in dependencies (already present)
+- Add env var workaround for ALSA pkg-config path in `.cargo/config.toml`
+
+### Step 5: Verify build and tests pass
+
+- `PKG_CONFIG_PATH=/tmp/alsa-pkg cargo test -p engine`
+- `PKG_CONFIG_PATH=/tmp/alsa-pkg cargo build -p engine --release`

--- a/.workflow/tasks/step4-clock-thread.md
+++ b/.workflow/tasks/step4-clock-thread.md
@@ -1,7 +1,7 @@
 # Task: Clock Thread
 
 - **Type**: coder
-- **Status**: in-progress
+- **Status**: done
 - **Repo**: midi-man-mk3
 - **Parallel Group**: 3
 - **Feature Branch**: feature/engine-phase1
@@ -76,3 +76,23 @@ The clock thread holds the write lock only for the duration of calling `state.ti
 
 ## Notes
 
+### Implementation Summary
+
+Implemented on branch `clock-thread` (worktree at `.workflow/worktrees/clock-thread`),
+based off `feature/engine-phase1`.
+
+**Files added/modified:**
+- `engine/src/clock.rs` — `run_clock()` + pure helper functions + 17 unit tests
+- `engine/src/state.rs` — copied from step3 worktree (SequencerState, MidiEvent, StepSize)
+- `engine/src/sequencer.rs` — copied from step3 worktree (re-exports)
+- `engine/src/lib.rs` — added state, sequencer, clock module declarations
+- `engine/Cargo.toml` — made midir/hidapi/ratatui/crossterm optional under `hw-io` feature so `cargo test -p engine` runs without system ALSA/hidraw dev packages
+
+**Key design decisions honored:**
+- `libc::clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME)` with absolute wake times
+- Tick period recomputed each iteration; swing offset on odd steps
+- NoteOn carries `duration_nanos = tick_nanos`; no NoteOff sent
+- SCHED_FIFO priority 50 attempted; non-fatal if denied
+- Thread exits on `midi_tx` disconnect
+
+**Test results:** 87 tests pass (`cargo test -p engine`); clippy clean; release build succeeds.

--- a/.workflow/tasks/step4-clock-thread.md
+++ b/.workflow/tasks/step4-clock-thread.md
@@ -96,3 +96,65 @@ based off `feature/engine-phase1`.
 - Thread exits on `midi_tx` disconnect
 
 **Test results:** 87 tests pass (`cargo test -p engine`); clippy clean; release build succeeds.
+
+---
+
+### Code Review Findings (2026-05-02)
+
+**Reviewer:** code-reviewer agent
+**Status:** request-changes
+**Summary:** 0 critical, 1 warning, several info findings
+
+#### Checklist — all items verified PASS unless noted
+
+- [x] `clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME)` — correct, line 91–94
+- [x] Tick period formula `60_000_000_000 / (bpm * steps_per_beat)` — correct, lines 31–33; steps_per_beat returns 1/2/4 for Quarter/Eighth/Sixteenth
+- [x] Swing offset applied on odd steps only (`step_count % 2 == 1`) — correct, lines 153–158
+- [x] Write lock held only for `state.tick()` — released immediately after, lines 165–167
+- [x] `duration_nanos` set to `tick_nanos` (called `period`) on NoteOn before sending, lines 170–175
+- [x] No NoteOff sent by clock — only NoteOn forwarded, confirmed
+- [x] SCHED_FIFO requested non-fatally — warning to stderr on failure, continues, lines 53–63
+- [x] Thread exits cleanly on channel disconnect (`send().is_err()` → break), line 176–179
+- [x] `hw-io` feature flag wires optional deps correctly in `engine/Cargo.toml`; `cargo test -p engine` passes without the flag (87 tests pass)
+
+#### [WARNING] `add_nanos_signed` drops `tv_sec` borrow on negative swing overflow
+
+- **File:** `engine/src/clock.rs`, lines 114–124
+- **Severity:** warning
+
+`add_nanos_signed` adds the signed nanosecond offset only to `tv_nsec`, then clamps the result to `max(0)`. When a negative swing offset exceeds `tv_nsec` (crossing a whole-second boundary), the borrow from `tv_sec` is silently discarded. The returned wake time has the original `tv_sec` and `tv_nsec=0` instead of `tv_sec-1` with the correct sub-second remainder.
+
+For 120 BPM sixteenth note steps with swing=-50, the offset is -62.5 ms. Any tick that starts within the first 62.5 ms of a second will produce a wake time ~62–1000 ms too late (pinned to the second boundary). `clock_nanosleep` with a past absolute time fires immediately, so odd steps fire too early rather than at the correct swing time.
+
+The existing test `add_nanos_signed_clamps_to_zero` only checks `tv_nsec >= 0`, missing the `tv_sec` error.
+
+**Suggested fix:**
+
+```rust
+fn add_nanos_signed(ts: libc::timespec, nanos: i64) -> libc::timespec {
+    let total_ns: i64 = ts.tv_sec as i64 * 1_000_000_000 + ts.tv_nsec + nanos;
+    let total_ns = total_ns.max(0);
+    libc::timespec {
+        tv_sec: (total_ns / 1_000_000_000) as libc::time_t,
+        tv_nsec: (total_ns % 1_000_000_000) as libc::c_long,
+    }
+}
+```
+
+Also update `add_nanos_signed_clamps_to_zero` to assert the corrected `tv_sec` value. Filed as BUG-002 in `.workflow/BUGS.md`.
+
+#### [INFO] `step_count` advances while `playing=false`
+
+- **File:** `engine/src/clock.rs`, line 185
+- **Severity:** info
+
+`step_count` (used for even/odd swing parity) increments unconditionally each tick, including when the sequencer is paused or stopped. On resume, the swing phase may not align with the playhead's actual even/odd position in the pattern. This is an intentional design note in the code comment ("does not reset with playhead") but is worth tracking as it can create subtle swing misalignment after pause/resume. Not a bug in the current spec, but worth revisiting when transport controls are wired.
+
+#### [INFO] Swing clamping philosophy
+
+- **File:** `engine/src/clock.rs`, lines 113–124 (doc comment)
+- **Severity:** info
+
+The doc comment says "clamped to 0 so they don't go before the beat" but negative swing is explicitly in-spec (-50 to +50). The intent is that a step should not fire before its nominal beat position, which is reasonable, but the actual behaviour (when the bug above is fixed) is that only cross-second-boundary cases get clamped. Small negative offsets that stay within the current second work correctly. The comment should be clarified.
+
+**Overall verdict:** request-changes — the `add_nanos_signed` bug (BUG-002) causes incorrect absolute wake times for negative swing values that cross a second boundary. Fix is straightforward. All other acceptance criteria pass.

--- a/.workflow/tasks/step5-midi-output.md
+++ b/.workflow/tasks/step5-midi-output.md
@@ -104,3 +104,73 @@ Build-time note: `midir` with the ALSA backend requires `libasound2-dev` install
 - [x] Thread exits when rx disconnected
 - [x] Unit tests via MockSender trait double (11 tests)
 - [x] `cargo test -p engine` passes
+
+---
+
+### Code Review — 2026-05-02
+
+**Reviewer:** code-reviewer agent
+**File reviewed:** `engine/src/midi_out.rs`, `.cargo/config.toml`
+
+#### MidiSender trait — soundness
+
+The trait is well-designed for testability. `Send + 'static` bounds are correct and necessary for the spawned note-off thread closures that capture `Box<dyn MidiSender>`. `try_clone` returning `Box<dyn MidiSender>` (rather than requiring `Clone`) is the right approach since `MidiOutputConnection` is not `Clone`. No issues.
+
+#### Arc<Mutex<MidiOutputConnection>> — lock discipline
+
+VERIFIED CORRECT. The lock is acquired only inside `send_bytes` (lines 35–38), held for the duration of `guard.send(data)`, and released immediately when the guard drops at the end of the block. The spawned note-off thread (lines 95–99) calls `thread::sleep` BEFORE calling `off_sender.send_bytes()`. The mutex is not held during the sleep. Lock discipline is sound.
+
+#### NoteOn spawned thread — lock not held during sleep
+
+VERIFIED CORRECT. The closure captures `off_sender: Box<dyn MidiSender>` and `channel`, `note`, `duration_nanos` by move. The sequence is: sleep → lock → send → unlock. The lock is never held across the sleep. No deadlock risk.
+
+#### Stack-only send path
+
+VERIFIED. All MIDI messages are `[u8; 1]` or `[u8; 3]` stack arrays. No `Vec`, `Box`, or heap allocation appears on the `dispatch()` hot path itself. The `Box<dyn MidiSender>` is allocated once at setup, not per-send. `off_sender` is moved into the spawned thread (a one-time allocation per NoteOn). Compliant with requirements.
+
+#### No panic on no ALSA ports
+
+VERIFIED. `open_first_port()` returns `None` on all failure paths (MidiOutput creation failure, empty port list, connection failure). `run_midi_out` returns early on `None`. No panics possible from missing ports.
+
+#### Thread exits when rx closes
+
+VERIFIED. `while let Ok(event) = rx.recv()` exits cleanly when the sender is dropped (recv returns `Err(RecvError)`). No blocking or resource leak.
+
+#### Test completeness (11 tests)
+
+Tests cover: NoteOn immediate bytes, NoteOn spawns note-off after duration, NoteOn channel masking, NoteOff bytes, NoteOff channel masking, Start, Stop, Continue, channel disconnect, channel round-trip. All five event types are covered. Mock correctly records byte output and uses `Arc<Mutex<Vec<u8>>>` to support inspection from the test thread after spawned threads complete.
+
+One observation: `note_on_sends_correct_bytes_immediately` and `note_on_channel_bits_masked_correctly` use `duration_nanos: 0` and sleep 20 ms to let the spawned NoteOff thread flush. This makes tests timing-dependent in theory, but with a 20 ms window it is robust enough for unit tests. No finding raised.
+
+#### Findings
+
+### [WARNING] `.cargo/config.toml` — hardcoded `/tmp` paths will silently break builds on clean systems
+
+- **File:** `.cargo/config.toml`, lines 11 and 17
+- **Severity:** warning
+- **Description:** `PKG_CONFIG_PATH = "/tmp/alsa-pkg"` and `rustflags = ["-L", "/tmp/alsa-lib"]` are unconditional. On a system where `alsa-lib-devel` is properly installed (CI, another developer's machine, a container), these paths will either not exist or point at the wrong `.so`. The `[env]` table in Cargo config does not support fallback/conditional logic, but the `rustflags` override is the more dangerous part: if `/tmp/alsa-lib` does not exist or contains a stale symlink, the linker will emit a spurious `-L` flag warning or, if the real `libasound.so` is on a different search path, the build may link against the wrong library silently. This is a host-specific workaround committed to source and will affect every developer and every CI environment that checks out the branch.
+- **Suggested fix:** Remove these entries from `.cargo/config.toml` and instead document the workaround in a comment or `README` section. Developers on hosts missing `alsa-lib-devel` can set `PKG_CONFIG_PATH` and `RUSTFLAGS` in their shell or in a gitignored `.cargo/config.local.toml`. Alternatively, gate the entries with an environment check in CI (e.g., only set them if `/tmp/alsa-pkg` exists) at the CI script level rather than baking them into config committed to source.
+
+### [INFO] `dispatch` takes `&mut Box<dyn MidiSender>` — double indirection is unnecessary
+
+- **File:** `engine/src/midi_out.rs`, line 86
+- **Severity:** info
+- **Description:** `dispatch(sender: &mut Box<dyn MidiSender>, ...)` introduces a double indirection: a mutable reference to a `Box`. The idiomatic Rust signature would be `dispatch(sender: &mut dyn MidiSender, ...)` which coerces cleanly from `&mut *boxed_sender` at the call site. This is a minor style issue with no correctness impact.
+- **Suggested fix:** Change the signature to `pub fn dispatch(sender: &mut dyn MidiSender, event: MidiEvent)` and update the two call sites to pass `sender.as_mut()` or `&mut **sender`.
+
+### [INFO] Spawned note-off threads are fire-and-forget with no accounting
+
+- **File:** `engine/src/midi_out.rs`, line 95
+- **Severity:** info
+- **Description:** `thread::spawn` for note-off scheduling produces threads with no handle tracked. For the MVP with short durations this is fine. At higher step rates (e.g., 120 BPM sixteenth = 125 ms steps, many notes), the number of in-flight threads will remain bounded by the note duration in ms / step period. No immediate risk, but worth noting for future gate-length design.
+- **Suggested fix:** No action required for MVP. If note durations grow large (> 1 second), consider a lightweight timer wheel or a single dedicated note-off thread consuming a priority queue.
+
+#### Summary
+
+- 0 critical findings
+- 1 warning finding (`.cargo/config.toml` hardcoded `/tmp` paths)
+- 2 info findings (double indirection signature, fire-and-forget threads)
+- All acceptance criteria verified correct
+- Lock discipline verified sound — mutex is never held during sleep
+- Test coverage is complete for all five event types
+- **Verdict: approve** (warning is a build-hygiene issue, not a correctness bug; does not block merge)

--- a/.workflow/tasks/step5-midi-output.md
+++ b/.workflow/tasks/step5-midi-output.md
@@ -1,7 +1,7 @@
 # Task: MIDI Output
 
 - **Type**: coder
-- **Status**: in-progress
+- **Status**: done
 - **Repo**: midi-man-mk3
 - **Parallel Group**: 3
 - **Feature Branch**: feature/engine-phase1
@@ -76,3 +76,31 @@ Build-time note: `midir` with the ALSA backend requires `libasound2-dev` install
 
 ## Notes
 
+### Implementation Summary
+
+**Branch:** `engine-phase1/midi-output` (worktree at `.workflow/worktrees/midi-output`)
+
+**What was implemented:**
+
+- `engine/src/midi_out.rs` — `pub fn run_midi_out(rx: Receiver<MidiEvent>)` and `pub fn run_midi_out_with_sender(rx, sender)` (testable entry point).
+- `MidiSender` trait abstracts the send path; production impl wraps `midir::MidiOutputConnection` behind `Arc<Mutex<…>>` so spawned note-off threads can share it without Clone.
+- `dispatch()` handles all five `MidiEvent` variants: NoteOn (immediate send + spawned note-off thread), NoteOff, Start (0xFA), Stop (0xFC), Continue (0xFB). All messages are `[u8; N]` stack arrays — no heap on send path.
+- On no ALSA ports: logs error and returns (no panic).
+- Also brought in `state.rs` and `sequencer.rs` from `sequencer-state-and-engine` branch; updated `lib.rs` to declare all modules.
+- `.cargo/config.toml` updated with `[env] PKG_CONFIG_PATH = "/tmp/alsa-pkg"` and `rustflags = ["-L", "/tmp/alsa-lib"]` workaround (alsa-lib-devel not installed on this host; symlink `/tmp/alsa-lib/libasound.so -> /usr/lib64/libasound.so.2`).
+
+**Test results:** 80 tests pass (`cargo test -p engine`); clippy clean; release build succeeds.
+
+**Acceptance criteria checklist:**
+- [x] `run_midi_out(rx: Receiver<MidiEvent>)` implemented
+- [x] Opens first ALSA port, logs name
+- [x] No ports → log error, return (no panic)
+- [x] NoteOn → `[0x90|ch, note, vel]` immediately + spawned note-off thread
+- [x] NoteOff → `[0x80|ch, note, 0]`
+- [x] Start → `[0xFA]`
+- [x] Stop → `[0xFC]`
+- [x] Continue → `[0xFB]`
+- [x] All messages on stack — no Vec/Box on send path
+- [x] Thread exits when rx disconnected
+- [x] Unit tests via MockSender trait double (11 tests)
+- [x] `cargo test -p engine` passes

--- a/engine/src/hid.rs
+++ b/engine/src/hid.rs
@@ -281,8 +281,7 @@ mod tests {
 
     #[test]
     fn in_report_field_offsets_match_wire_spec() {
-        // Use a zeroed buffer and observe which byte changes when we set each
-        // field to a sentinel value, verifying the offset matches the spec.
+        // Verify field offsets using std::mem::offset_of! (stable since Rust 1.77).
         //
         // Spec:
         //   Byte  0   : report_id
@@ -296,47 +295,16 @@ mod tests {
         //   Byte 26   : param_knob_delta
         //   Bytes 27-63: reserved[37]
 
-        // Build a report with one distinct sentinel per field group, then
-        // call to_bytes via unsafe memcpy to inspect raw layout.
-        let report = InReport {
-            report_id: 0x01,
-            seq: 0x02,
-            flags: 0x03,
-            step_buttons: [0x04, 0x05],
-            step_enable_state: [0x06, 0x07],
-            param_buttons: [0x08, 0x09],
-            encoder_deltas: [0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
-                             0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
-                             0x16, 0x17, 0x18, 0x19],
-            tempo_delta: 0x1A,
-            param_knob_delta: 0x1B,
-            reserved: [0u8; 37],
-        };
-
-        // Read the struct as raw bytes via pointer cast (safe: repr(C), no padding, u8 alignment >= 1).
-        let raw: [u8; 64] = unsafe {
-            std::mem::transmute(report)
-        };
-
-        assert_eq!(raw[0], 0x01, "report_id must be at byte 0");
-        assert_eq!(raw[1], 0x02, "seq must be at byte 1");
-        assert_eq!(raw[2], 0x03, "flags must be at byte 2");
-        assert_eq!(raw[3], 0x04, "step_buttons[0] must be at byte 3");
-        assert_eq!(raw[4], 0x05, "step_buttons[1] must be at byte 4");
-        assert_eq!(raw[5], 0x06, "step_enable_state[0] must be at byte 5");
-        assert_eq!(raw[6], 0x07, "step_enable_state[1] must be at byte 6");
-        assert_eq!(raw[7], 0x08, "param_buttons[0] must be at byte 7");
-        assert_eq!(raw[8], 0x09, "param_buttons[1] must be at byte 8");
-        for i in 0..16usize {
-            assert_eq!(raw[9 + i], 0x0A + i as u8,
-                "encoder_deltas[{i}] must be at byte {}", 9 + i);
-        }
-        assert_eq!(raw[25], 0x1A, "tempo_delta must be at byte 25");
-        assert_eq!(raw[26], 0x1B, "param_knob_delta must be at byte 26");
-        // reserved bytes 27-63 should all be 0
-        for i in 27..64usize {
-            assert_eq!(raw[i], 0x00, "reserved byte {i} must be zero");
-        }
+        assert_eq!(std::mem::offset_of!(InReport, report_id), 0, "report_id must be at byte 0");
+        assert_eq!(std::mem::offset_of!(InReport, seq), 1, "seq must be at byte 1");
+        assert_eq!(std::mem::offset_of!(InReport, flags), 2, "flags must be at byte 2");
+        assert_eq!(std::mem::offset_of!(InReport, step_buttons), 3, "step_buttons must start at byte 3");
+        assert_eq!(std::mem::offset_of!(InReport, step_enable_state), 5, "step_enable_state must start at byte 5");
+        assert_eq!(std::mem::offset_of!(InReport, param_buttons), 7, "param_buttons must start at byte 7");
+        assert_eq!(std::mem::offset_of!(InReport, encoder_deltas), 9, "encoder_deltas must start at byte 9");
+        assert_eq!(std::mem::offset_of!(InReport, tempo_delta), 25, "tempo_delta must be at byte 25");
+        assert_eq!(std::mem::offset_of!(InReport, param_knob_delta), 26, "param_knob_delta must be at byte 26");
+        assert_eq!(std::mem::offset_of!(InReport, reserved), 27, "reserved must start at byte 27");
     }
 
     #[test]

--- a/engine/src/hid.rs
+++ b/engine/src/hid.rs
@@ -116,6 +116,32 @@ impl OutReport {
     }
 }
 
+/// Non-fatal HID device opener.
+///
+/// Returns `Some(device)` when the device is found and opened, or `None` when
+/// it is unavailable.  Errors are logged to stderr so the engine can continue
+/// with keyboard-only input.
+#[cfg(feature = "hw-io")]
+pub fn open_device() -> Option<hidapi::HidDevice> {
+    let api = match hidapi::HidApi::new() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("warn: hidapi init failed ({e}) — running without HID device");
+            return None;
+        }
+    };
+    match api.open(HID_VID, HID_PID) {
+        Ok(dev) => Some(dev),
+        Err(e) => {
+            eprintln!(
+                "warn: could not open HID device {:04X}:{:04X} ({e}) — running without HID device",
+                HID_VID, HID_PID
+            );
+            None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/engine/src/input.rs
+++ b/engine/src/input.rs
@@ -1,0 +1,236 @@
+//! Input command abstraction — the single type flowing from all input sources into state.
+//!
+//! Both the keyboard handler (`ui.rs`) and the HID reader (Step 7) produce
+//! `InputCommand` values on a shared `SyncSender<InputCommand>`.  State
+//! mutation is handled exclusively in `SequencerState::apply_command`.
+
+/// The overlay mode active when an F1/F2 overlay is open.
+///
+/// Canonical definition — `state.rs` imports this instead of defining its own stub.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OverlayMode {
+    /// Normal (non-shift) overlay — F1.
+    Regular,
+    /// Shift overlay — F2; secondary functions active.
+    Shift,
+}
+
+/// Every user action that can mutate sequencer state.
+///
+/// Produced by the keyboard loop (`ui.rs`) and the HID thread (Step 7).
+/// Consumed by `SequencerState::apply_command`.
+#[derive(Clone, Debug)]
+pub enum InputCommand {
+    /// Jump to an absolute step index (0–15).
+    StepSelect(usize),
+    /// Move the selected step by a signed delta; wraps modulo 16.
+    StepSelectDelta(i8),
+    /// Adjust the MIDI note for the selected step by `delta` semitones.
+    NoteDelta(i8),
+    /// Commit the pending edit to live state; no-op if no edit is pending.
+    Confirm,
+    /// Toggle the enabled state of the currently selected step.
+    ToggleStep,
+    /// Adjust the velocity for the selected step by `delta`.
+    VelocityDelta(i8),
+    /// Open the F1 (Regular) or F2 (Shift) overlay.
+    OpenOverlay(OverlayMode),
+    /// Close the active overlay and discard any pending param edit.
+    CloseOverlay,
+    /// Jump to an absolute param index.
+    ParamSelect(u8),
+    /// Move the selected param by a signed delta.
+    ParamSelectDelta(i8),
+    /// Adjust the value of the currently selected param by `delta`.
+    ParamValueDelta(i8),
+}
+
+/// Pure function: translate a root-mode key event into an `InputCommand`.
+///
+/// Separated from crossterm so it can be unit-tested without the hw-io feature.
+/// `shift` is true when the Shift modifier is held.
+/// Returns `None` for unmapped keys.
+pub fn root_key_to_command(
+    key_code: KeyCodeSimple,
+    shift: bool,
+) -> Option<InputCommand> {
+    match key_code {
+        KeyCodeSimple::Left => Some(InputCommand::StepSelectDelta(-1)),
+        KeyCodeSimple::Right => Some(InputCommand::StepSelectDelta(1)),
+        KeyCodeSimple::Up if shift => Some(InputCommand::VelocityDelta(1)),
+        KeyCodeSimple::Down if shift => Some(InputCommand::VelocityDelta(-1)),
+        KeyCodeSimple::Up => Some(InputCommand::NoteDelta(1)),
+        KeyCodeSimple::Down => Some(InputCommand::NoteDelta(-1)),
+        KeyCodeSimple::Space => Some(InputCommand::ToggleStep),
+        KeyCodeSimple::Enter => Some(InputCommand::Confirm),
+        KeyCodeSimple::F1 => Some(InputCommand::OpenOverlay(OverlayMode::Regular)),
+        KeyCodeSimple::F2 => Some(InputCommand::OpenOverlay(OverlayMode::Shift)),
+        _ => None,
+    }
+}
+
+/// Pure function: translate an overlay-mode key event into an `InputCommand`.
+///
+/// Returns `None` for unmapped keys.
+pub fn overlay_key_to_command(key_code: KeyCodeSimple) -> Option<InputCommand> {
+    match key_code {
+        KeyCodeSimple::Left => Some(InputCommand::ParamSelectDelta(-1)),
+        KeyCodeSimple::Right => Some(InputCommand::ParamSelectDelta(1)),
+        KeyCodeSimple::Up => Some(InputCommand::ParamValueDelta(1)),
+        KeyCodeSimple::Down => Some(InputCommand::ParamValueDelta(-1)),
+        KeyCodeSimple::Enter => Some(InputCommand::Confirm),
+        KeyCodeSimple::Esc => Some(InputCommand::CloseOverlay),
+        _ => None,
+    }
+}
+
+/// A minimal key code enum that mirrors the subset of crossterm keys we care
+/// about.  This lives in `input.rs` (no feature gate) so the translation
+/// functions can be unit-tested without the `hw-io` feature.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KeyCodeSimple {
+    /// Left arrow.
+    Left,
+    /// Right arrow.
+    Right,
+    /// Up arrow.
+    Up,
+    /// Down arrow.
+    Down,
+    /// Space bar.
+    Space,
+    /// Enter / Return.
+    Enter,
+    /// Escape.
+    Esc,
+    /// F1.
+    F1,
+    /// F2.
+    F2,
+    /// Any other key (ignored).
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- root_key_to_command ---
+
+    #[test]
+    fn root_left_arrow_is_step_select_delta_minus_1() {
+        let cmd = root_key_to_command(KeyCodeSimple::Left, false);
+        assert!(matches!(cmd, Some(InputCommand::StepSelectDelta(-1))));
+    }
+
+    #[test]
+    fn root_right_arrow_is_step_select_delta_plus_1() {
+        let cmd = root_key_to_command(KeyCodeSimple::Right, false);
+        assert!(matches!(cmd, Some(InputCommand::StepSelectDelta(1))));
+    }
+
+    #[test]
+    fn root_up_arrow_no_shift_is_note_delta_plus_1() {
+        let cmd = root_key_to_command(KeyCodeSimple::Up, false);
+        assert!(matches!(cmd, Some(InputCommand::NoteDelta(1))));
+    }
+
+    #[test]
+    fn root_down_arrow_no_shift_is_note_delta_minus_1() {
+        let cmd = root_key_to_command(KeyCodeSimple::Down, false);
+        assert!(matches!(cmd, Some(InputCommand::NoteDelta(-1))));
+    }
+
+    #[test]
+    fn root_up_arrow_with_shift_is_velocity_delta_plus_1() {
+        let cmd = root_key_to_command(KeyCodeSimple::Up, true);
+        assert!(matches!(cmd, Some(InputCommand::VelocityDelta(1))));
+    }
+
+    #[test]
+    fn root_down_arrow_with_shift_is_velocity_delta_minus_1() {
+        let cmd = root_key_to_command(KeyCodeSimple::Down, true);
+        assert!(matches!(cmd, Some(InputCommand::VelocityDelta(-1))));
+    }
+
+    #[test]
+    fn root_space_is_toggle_step() {
+        let cmd = root_key_to_command(KeyCodeSimple::Space, false);
+        assert!(matches!(cmd, Some(InputCommand::ToggleStep)));
+    }
+
+    #[test]
+    fn root_enter_is_confirm() {
+        let cmd = root_key_to_command(KeyCodeSimple::Enter, false);
+        assert!(matches!(cmd, Some(InputCommand::Confirm)));
+    }
+
+    #[test]
+    fn root_f1_opens_regular_overlay() {
+        let cmd = root_key_to_command(KeyCodeSimple::F1, false);
+        assert!(matches!(cmd, Some(InputCommand::OpenOverlay(OverlayMode::Regular))));
+    }
+
+    #[test]
+    fn root_f2_opens_shift_overlay() {
+        let cmd = root_key_to_command(KeyCodeSimple::F2, false);
+        assert!(matches!(cmd, Some(InputCommand::OpenOverlay(OverlayMode::Shift))));
+    }
+
+    #[test]
+    fn root_other_key_returns_none() {
+        let cmd = root_key_to_command(KeyCodeSimple::Other, false);
+        assert!(cmd.is_none());
+    }
+
+    #[test]
+    fn root_esc_returns_none_in_root_mode() {
+        // Esc is only mapped in overlay mode.
+        let cmd = root_key_to_command(KeyCodeSimple::Esc, false);
+        assert!(cmd.is_none());
+    }
+
+    // --- overlay_key_to_command ---
+
+    #[test]
+    fn overlay_left_is_param_select_delta_minus_1() {
+        let cmd = overlay_key_to_command(KeyCodeSimple::Left);
+        assert!(matches!(cmd, Some(InputCommand::ParamSelectDelta(-1))));
+    }
+
+    #[test]
+    fn overlay_right_is_param_select_delta_plus_1() {
+        let cmd = overlay_key_to_command(KeyCodeSimple::Right);
+        assert!(matches!(cmd, Some(InputCommand::ParamSelectDelta(1))));
+    }
+
+    #[test]
+    fn overlay_up_is_param_value_delta_plus_1() {
+        let cmd = overlay_key_to_command(KeyCodeSimple::Up);
+        assert!(matches!(cmd, Some(InputCommand::ParamValueDelta(1))));
+    }
+
+    #[test]
+    fn overlay_down_is_param_value_delta_minus_1() {
+        let cmd = overlay_key_to_command(KeyCodeSimple::Down);
+        assert!(matches!(cmd, Some(InputCommand::ParamValueDelta(-1))));
+    }
+
+    #[test]
+    fn overlay_enter_is_confirm() {
+        let cmd = overlay_key_to_command(KeyCodeSimple::Enter);
+        assert!(matches!(cmd, Some(InputCommand::Confirm)));
+    }
+
+    #[test]
+    fn overlay_esc_is_close_overlay() {
+        let cmd = overlay_key_to_command(KeyCodeSimple::Esc);
+        assert!(matches!(cmd, Some(InputCommand::CloseOverlay)));
+    }
+
+    #[test]
+    fn overlay_other_returns_none() {
+        let cmd = overlay_key_to_command(KeyCodeSimple::Other);
+        assert!(cmd.is_none());
+    }
+}

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -1,3 +1,5 @@
+/// Input command abstraction — InputCommand and OverlayMode enums.
+pub mod input;
 /// USB HID report structures for the MIDI controller.
 pub mod hid;
 /// Music theory primitives: keys, modes, scale tables, and note navigation.
@@ -11,3 +13,6 @@ pub mod clock;
 /// MIDI output thread — sends NoteOn/NoteOff via midir.
 #[cfg(feature = "hw-io")]
 pub mod midi_out;
+/// Keyboard UI event loop — translates crossterm KeyEvent to InputCommand.
+#[cfg(feature = "hw-io")]
+pub mod ui;

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -916,4 +916,98 @@ mod tests {
         let s = SequencerState::default();
         assert_eq!(s.selected_param, 0);
     }
+
+    // --- apply_command: boundary conditions not yet covered ---
+
+    #[test]
+    fn apply_command_param_select_clamps_at_6() {
+        // ParamSelect(n) should clamp n to the valid range 0–6.
+        let mut s = SequencerState::default();
+        s.apply_command(InputCommand::ParamSelect(10));
+        assert_eq!(s.selected_param, 6, "ParamSelect(10) should clamp to 6");
+    }
+
+    #[test]
+    fn apply_command_close_overlay_with_no_pending_is_noop() {
+        // CloseOverlay with PendingEdit::None should leave pending_edit as None.
+        let mut s = SequencerState::default();
+        assert!(matches!(s.pending_edit, PendingEdit::None));
+        s.apply_command(InputCommand::CloseOverlay);
+        assert!(matches!(s.pending_edit, PendingEdit::None));
+        assert!(s.active_overlay.is_none());
+    }
+
+    #[test]
+    fn apply_command_step_select_delta_with_no_pending_leaves_pending_none() {
+        // StepSelectDelta when pending_edit is None should not change pending_edit.
+        let mut s = SequencerState::default();
+        s.selected_step = 5;
+        s.apply_command(InputCommand::StepSelectDelta(1));
+        assert_eq!(s.selected_step, 6);
+        assert!(matches!(s.pending_edit, PendingEdit::None));
+    }
+
+    #[test]
+    fn apply_command_confirm_with_pending_velocity_commits_to_correct_step() {
+        // Confirm with PendingEdit::Velocity commits the velocity to the exact step
+        // referenced in the edit, not the currently selected step.
+        let mut s = SequencerState::default();
+        s.selected_step = 0;
+        // Simulate: user moved to step 3, set velocity, then moved back to step 0.
+        s.pending_edit = PendingEdit::Velocity { step: 3, velocity: 64 };
+        s.apply_command(InputCommand::Confirm);
+        assert_eq!(s.steps[3].velocity, 64, "velocity committed to step 3");
+        // Other steps must be untouched.
+        assert_eq!(s.steps[0].velocity, 100, "step 0 velocity must be default");
+        assert!(matches!(s.pending_edit, PendingEdit::None));
+    }
+
+    #[test]
+    fn apply_command_confirm_param_clears_pending_edit() {
+        // Confirm with PendingEdit::Param clears the pending edit.
+        // Actual param application is deferred to Step 7; here we verify
+        // the pending edit is cleared so it does not accumulate.
+        let mut s = SequencerState::default();
+        s.active_overlay = Some(OverlayMode::Regular);
+        s.pending_edit = PendingEdit::Param { overlay: OverlayMode::Regular, index: 4, value: -3 };
+        s.apply_command(InputCommand::Confirm);
+        assert!(matches!(s.pending_edit, PendingEdit::None));
+    }
+
+    // --- tick: velocity round-trips ---
+
+    #[test]
+    fn tick_note_on_uses_step_velocity_64() {
+        // A step with velocity=64 must produce NoteOn with velocity=64 (not the
+        // former hardcoded 100).
+        let mut s = SequencerState::default();
+        s.playing = true;
+        s.steps[1].enabled = true;
+        s.steps[1].midi_note = 60;
+        s.steps[1].velocity = 64;
+        s.playhead = 0; // next tick advances to 1
+        let evt = s.tick();
+        assert_eq!(
+            evt,
+            Some(MidiEvent::NoteOn { channel: 0, note: 60, velocity: 64, duration_nanos: 0 }),
+            "NoteOn velocity must match step.velocity=64"
+        );
+    }
+
+    #[test]
+    fn tick_note_on_uses_step_velocity_1() {
+        // A step with velocity=1 (near minimum) must produce NoteOn with velocity=1.
+        let mut s = SequencerState::default();
+        s.playing = true;
+        s.steps[1].enabled = true;
+        s.steps[1].midi_note = 48;
+        s.steps[1].velocity = 1;
+        s.playhead = 0;
+        let evt = s.tick();
+        assert_eq!(
+            evt,
+            Some(MidiEvent::NoteOn { channel: 0, note: 48, velocity: 1, duration_nanos: 0 }),
+            "NoteOn velocity must match step.velocity=1"
+        );
+    }
 }

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -182,7 +182,7 @@ impl SequencerState {
             Some(MidiEvent::NoteOn {
                 channel: 0,
                 note: step.midi_note,
-                velocity: 100,
+                velocity: step.velocity,
                 duration_nanos: 0,
             })
         } else {
@@ -266,7 +266,7 @@ impl SequencerState {
                 }
             }
             InputCommand::ParamSelect(n) => {
-                self.selected_param = n;
+                self.selected_param = n.min(6);
             }
             InputCommand::ParamSelectDelta(d) => {
                 // 7 params (indices 0–6), wrap modulo 7.
@@ -646,9 +646,10 @@ mod tests {
         s.playing = true;
         s.steps[1].enabled = true;
         s.steps[1].midi_note = 72;
+        s.steps[1].velocity = 80;
 
         s.tick(); // move to step 1
-        // step 1 is enabled with note 72
+        // step 1 is enabled with note 72 and velocity 80
         // (playhead was at 0, so first tick moves to 1)
         let evt = {
             // Reset and re-tick cleanly
@@ -657,7 +658,7 @@ mod tests {
         };
         assert_eq!(
             evt,
-            Some(MidiEvent::NoteOn { channel: 0, note: 72, velocity: 100, duration_nanos: 0 })
+            Some(MidiEvent::NoteOn { channel: 0, note: 72, velocity: 80, duration_nanos: 0 })
         );
     }
 

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -3,17 +3,12 @@
 //! Wrap in `Arc<RwLock<SequencerState>>` at the call site (Step 9).
 //! All mutating methods take `&mut self`; callers hold the write lock.
 
+use crate::input::InputCommand;
 use crate::music_theory::{Key, Mode};
 
-/// Stub for OverlayMode until Step 6b wires up the real import from input.rs.
-/// Step 6b will replace this with `use crate::input::OverlayMode;`.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-pub enum OverlayMode {
-    /// Normal (non-shift) overlay.
-    Regular,
-    /// Shift overlay — secondary functions active.
-    Shift,
-}
+// Re-export OverlayMode from input so that existing code importing it from
+// state (e.g. sequencer.rs) continues to compile without modification.
+pub use crate::input::OverlayMode;
 
 /// Step resolution for the sequencer clock.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -46,11 +41,13 @@ pub struct StepData {
     pub enabled: bool,
     /// MIDI note number (0–127).
     pub midi_note: u8,
+    /// MIDI velocity (0–127).
+    pub velocity: u8,
 }
 
 impl Default for StepData {
     fn default() -> Self {
-        Self { enabled: false, midi_note: 60 }
+        Self { enabled: false, midi_note: 60, velocity: 100 }
     }
 }
 
@@ -106,6 +103,10 @@ pub struct SequencerState {
     pub pending_edit: PendingEdit,
     /// Active overlay mode; set by the command processor, read by the HID thread.
     pub active_overlay: Option<OverlayMode>,
+    /// Currently selected step (0–15); controlled by StepSelect/StepSelectDelta.
+    pub selected_step: usize,
+    /// Currently selected param index (0–6); controlled by ParamSelect/ParamSelectDelta.
+    pub selected_param: u8,
 }
 
 impl Default for SequencerState {
@@ -125,6 +126,8 @@ impl Default for SequencerState {
             paused: false,
             pending_edit: PendingEdit::None,
             active_overlay: None,
+            selected_step: 0,
+            selected_param: 0,
         }
     }
 }
@@ -184,6 +187,109 @@ impl SequencerState {
             })
         } else {
             None
+        }
+    }
+
+    /// Apply an `InputCommand` to the sequencer state.
+    ///
+    /// This is the single entry point for all state mutation driven by user
+    /// input.  Both the keyboard thread and the HID thread send `InputCommand`
+    /// values on a shared channel; the consumer calls this method while holding
+    /// the write lock.
+    pub fn apply_command(&mut self, cmd: InputCommand) {
+        match cmd {
+            InputCommand::StepSelect(n) => {
+                self.selected_step = n.min(15);
+                // Discard any pending note or velocity edit on step change.
+                if matches!(self.pending_edit, PendingEdit::Note { .. } | PendingEdit::Velocity { .. }) {
+                    self.pending_edit = PendingEdit::None;
+                }
+            }
+            InputCommand::StepSelectDelta(d) => {
+                // Wrapping arithmetic modulo 16.
+                let current = self.selected_step as i32;
+                let next = ((current + d as i32).rem_euclid(16)) as usize;
+                self.selected_step = next;
+                if matches!(self.pending_edit, PendingEdit::Note { .. } | PendingEdit::Velocity { .. }) {
+                    self.pending_edit = PendingEdit::None;
+                }
+            }
+            InputCommand::NoteDelta(d) => {
+                let step = self.selected_step;
+                let current_note = self.steps[step].midi_note;
+                // Saturating add so we stay in 0–127.
+                let new_note = (current_note as i16 + d as i16).clamp(0, 127) as u8;
+                self.pending_edit = PendingEdit::Note { step, midi_note: new_note };
+            }
+            InputCommand::Confirm => {
+                match self.pending_edit {
+                    PendingEdit::None => { /* no-op */ }
+                    PendingEdit::Note { step, midi_note } => {
+                        if step < 16 {
+                            self.steps[step].midi_note = midi_note;
+                        }
+                        self.pending_edit = PendingEdit::None;
+                    }
+                    PendingEdit::Velocity { step, velocity } => {
+                        if step < 16 {
+                            self.steps[step].velocity = velocity;
+                        }
+                        self.pending_edit = PendingEdit::None;
+                    }
+                    PendingEdit::Param { .. } => {
+                        // Param commits are handled by Step 7 (param overlay logic).
+                        // Clear the pending edit after confirmation.
+                        self.pending_edit = PendingEdit::None;
+                    }
+                }
+            }
+            InputCommand::ToggleStep => {
+                let step = self.selected_step;
+                self.toggle_step(step);
+            }
+            InputCommand::VelocityDelta(d) => {
+                let step = self.selected_step;
+                let current_vel = self.steps[step].velocity;
+                let new_vel = (current_vel as i16 + d as i16).clamp(0, 127) as u8;
+                self.pending_edit = PendingEdit::Velocity { step, velocity: new_vel };
+            }
+            InputCommand::OpenOverlay(mode) => {
+                // Record the active overlay so HID can read it.
+                // The UI thread also tracks this locally for rendering decisions.
+                self.active_overlay = Some(mode);
+            }
+            InputCommand::CloseOverlay => {
+                self.active_overlay = None;
+                // Discard any pending param edit.
+                if matches!(self.pending_edit, PendingEdit::Param { .. }) {
+                    self.pending_edit = PendingEdit::None;
+                }
+            }
+            InputCommand::ParamSelect(n) => {
+                self.selected_param = n;
+            }
+            InputCommand::ParamSelectDelta(d) => {
+                // 7 params (indices 0–6), wrap modulo 7.
+                let current = self.selected_param as i32;
+                let next = ((current + d as i32).rem_euclid(7)) as u8;
+                self.selected_param = next;
+            }
+            InputCommand::ParamValueDelta(d) => {
+                let overlay = match self.active_overlay {
+                    Some(m) => m,
+                    None => return, // No overlay open — ignore.
+                };
+                let index = self.selected_param;
+                let current_value = match self.pending_edit {
+                    PendingEdit::Param { index: pi, value, .. } if pi == index => value,
+                    _ => 0,
+                };
+                self.pending_edit = PendingEdit::Param {
+                    overlay,
+                    index,
+                    value: current_value + d as i64,
+                };
+            }
         }
     }
 }
@@ -553,5 +659,260 @@ mod tests {
             evt,
             Some(MidiEvent::NoteOn { channel: 0, note: 72, velocity: 100, duration_nanos: 0 })
         );
+    }
+
+    // --- apply_command ---
+
+    #[test]
+    fn apply_command_step_select_sets_selected_step() {
+        let mut s = SequencerState::default();
+        s.apply_command(InputCommand::StepSelect(7));
+        assert_eq!(s.selected_step, 7);
+    }
+
+    #[test]
+    fn apply_command_step_select_clamps_to_15() {
+        let mut s = SequencerState::default();
+        s.apply_command(InputCommand::StepSelect(20));
+        assert_eq!(s.selected_step, 15);
+    }
+
+    #[test]
+    fn apply_command_step_select_clears_pending_note_edit() {
+        let mut s = SequencerState::default();
+        s.pending_edit = PendingEdit::Note { step: 0, midi_note: 64 };
+        s.apply_command(InputCommand::StepSelect(3));
+        assert!(matches!(s.pending_edit, PendingEdit::None));
+    }
+
+    #[test]
+    fn apply_command_step_select_clears_pending_velocity_edit() {
+        let mut s = SequencerState::default();
+        s.pending_edit = PendingEdit::Velocity { step: 0, velocity: 80 };
+        s.apply_command(InputCommand::StepSelect(3));
+        assert!(matches!(s.pending_edit, PendingEdit::None));
+    }
+
+    #[test]
+    fn apply_command_step_select_does_not_clear_param_edit() {
+        let mut s = SequencerState::default();
+        s.active_overlay = Some(OverlayMode::Regular);
+        s.pending_edit = PendingEdit::Param { overlay: OverlayMode::Regular, index: 2, value: 5 };
+        s.apply_command(InputCommand::StepSelect(3));
+        assert!(matches!(s.pending_edit, PendingEdit::Param { .. }));
+    }
+
+    #[test]
+    fn apply_command_step_select_delta_wraps_at_15() {
+        let mut s = SequencerState::default();
+        s.selected_step = 15;
+        s.apply_command(InputCommand::StepSelectDelta(1));
+        assert_eq!(s.selected_step, 0, "wrapping past 15 should give 0");
+    }
+
+    #[test]
+    fn apply_command_step_select_delta_wraps_at_0() {
+        let mut s = SequencerState::default();
+        s.selected_step = 0;
+        s.apply_command(InputCommand::StepSelectDelta(-1));
+        assert_eq!(s.selected_step, 15, "wrapping below 0 should give 15");
+    }
+
+    #[test]
+    fn apply_command_step_select_delta_advances_normally() {
+        let mut s = SequencerState::default();
+        s.selected_step = 5;
+        s.apply_command(InputCommand::StepSelectDelta(3));
+        assert_eq!(s.selected_step, 8);
+    }
+
+    #[test]
+    fn apply_command_note_delta_sets_pending_note_edit() {
+        let mut s = SequencerState::default();
+        s.selected_step = 2;
+        // default midi_note = 60
+        s.apply_command(InputCommand::NoteDelta(1));
+        assert!(matches!(s.pending_edit, PendingEdit::Note { step: 2, midi_note: 61 }));
+    }
+
+    #[test]
+    fn apply_command_note_delta_negative_clamps_at_0() {
+        let mut s = SequencerState::default();
+        s.steps[0].midi_note = 0;
+        s.apply_command(InputCommand::NoteDelta(-5));
+        assert!(matches!(s.pending_edit, PendingEdit::Note { step: 0, midi_note: 0 }));
+    }
+
+    #[test]
+    fn apply_command_note_delta_positive_clamps_at_127() {
+        let mut s = SequencerState::default();
+        s.steps[0].midi_note = 127;
+        s.apply_command(InputCommand::NoteDelta(10));
+        assert!(matches!(s.pending_edit, PendingEdit::Note { step: 0, midi_note: 127 }));
+    }
+
+    #[test]
+    fn apply_command_confirm_commits_note_edit() {
+        let mut s = SequencerState::default();
+        s.pending_edit = PendingEdit::Note { step: 3, midi_note: 72 };
+        s.apply_command(InputCommand::Confirm);
+        assert_eq!(s.steps[3].midi_note, 72);
+        assert!(matches!(s.pending_edit, PendingEdit::None));
+    }
+
+    #[test]
+    fn apply_command_confirm_with_no_pending_is_noop() {
+        let mut s = SequencerState::default();
+        let note_before = s.steps[0].midi_note;
+        s.apply_command(InputCommand::Confirm);
+        assert_eq!(s.steps[0].midi_note, note_before);
+        assert!(matches!(s.pending_edit, PendingEdit::None));
+    }
+
+    #[test]
+    fn apply_command_confirm_commits_velocity_edit() {
+        let mut s = SequencerState::default();
+        s.pending_edit = PendingEdit::Velocity { step: 1, velocity: 90 };
+        s.apply_command(InputCommand::Confirm);
+        assert_eq!(s.steps[1].velocity, 90);
+        assert!(matches!(s.pending_edit, PendingEdit::None));
+    }
+
+    #[test]
+    fn apply_command_confirm_clears_param_edit() {
+        let mut s = SequencerState::default();
+        s.pending_edit = PendingEdit::Param { overlay: OverlayMode::Regular, index: 0, value: 3 };
+        s.apply_command(InputCommand::Confirm);
+        assert!(matches!(s.pending_edit, PendingEdit::None));
+    }
+
+    #[test]
+    fn apply_command_toggle_step_toggles_selected_step() {
+        let mut s = SequencerState::default();
+        s.selected_step = 4;
+        assert!(!s.steps[4].enabled);
+        s.apply_command(InputCommand::ToggleStep);
+        assert!(s.steps[4].enabled);
+        s.apply_command(InputCommand::ToggleStep);
+        assert!(!s.steps[4].enabled);
+    }
+
+    #[test]
+    fn apply_command_velocity_delta_sets_pending_velocity_edit() {
+        let mut s = SequencerState::default();
+        s.selected_step = 5;
+        // default velocity = 100
+        s.apply_command(InputCommand::VelocityDelta(10));
+        assert!(matches!(s.pending_edit, PendingEdit::Velocity { step: 5, velocity: 110 }));
+    }
+
+    #[test]
+    fn apply_command_velocity_delta_clamps_at_127() {
+        let mut s = SequencerState::default();
+        s.steps[0].velocity = 127;
+        s.apply_command(InputCommand::VelocityDelta(50));
+        assert!(matches!(s.pending_edit, PendingEdit::Velocity { step: 0, velocity: 127 }));
+    }
+
+    #[test]
+    fn apply_command_velocity_delta_clamps_at_0() {
+        let mut s = SequencerState::default();
+        s.steps[0].velocity = 0;
+        s.apply_command(InputCommand::VelocityDelta(-5));
+        assert!(matches!(s.pending_edit, PendingEdit::Velocity { step: 0, velocity: 0 }));
+    }
+
+    #[test]
+    fn apply_command_open_overlay_sets_active_overlay() {
+        let mut s = SequencerState::default();
+        s.apply_command(InputCommand::OpenOverlay(OverlayMode::Regular));
+        assert_eq!(s.active_overlay, Some(OverlayMode::Regular));
+        s.apply_command(InputCommand::OpenOverlay(OverlayMode::Shift));
+        assert_eq!(s.active_overlay, Some(OverlayMode::Shift));
+    }
+
+    #[test]
+    fn apply_command_close_overlay_clears_active_overlay() {
+        let mut s = SequencerState::default();
+        s.active_overlay = Some(OverlayMode::Regular);
+        s.apply_command(InputCommand::CloseOverlay);
+        assert!(s.active_overlay.is_none());
+    }
+
+    #[test]
+    fn apply_command_close_overlay_discards_param_edit() {
+        let mut s = SequencerState::default();
+        s.active_overlay = Some(OverlayMode::Regular);
+        s.pending_edit = PendingEdit::Param { overlay: OverlayMode::Regular, index: 0, value: 7 };
+        s.apply_command(InputCommand::CloseOverlay);
+        assert!(matches!(s.pending_edit, PendingEdit::None));
+    }
+
+    #[test]
+    fn apply_command_param_select_sets_selected_param() {
+        let mut s = SequencerState::default();
+        s.apply_command(InputCommand::ParamSelect(3));
+        assert_eq!(s.selected_param, 3);
+    }
+
+    #[test]
+    fn apply_command_param_select_delta_wraps_at_7() {
+        let mut s = SequencerState::default();
+        s.selected_param = 6;
+        s.apply_command(InputCommand::ParamSelectDelta(1));
+        assert_eq!(s.selected_param, 0, "param wraps past 6 to 0");
+    }
+
+    #[test]
+    fn apply_command_param_select_delta_wraps_at_0() {
+        let mut s = SequencerState::default();
+        s.selected_param = 0;
+        s.apply_command(InputCommand::ParamSelectDelta(-1));
+        assert_eq!(s.selected_param, 6, "param wraps below 0 to 6");
+    }
+
+    #[test]
+    fn apply_command_param_value_delta_sets_pending_param_edit() {
+        let mut s = SequencerState::default();
+        s.active_overlay = Some(OverlayMode::Regular);
+        s.selected_param = 2;
+        s.apply_command(InputCommand::ParamValueDelta(5));
+        assert!(matches!(
+            s.pending_edit,
+            PendingEdit::Param { overlay: OverlayMode::Regular, index: 2, value: 5 }
+        ));
+    }
+
+    #[test]
+    fn apply_command_param_value_delta_accumulates() {
+        let mut s = SequencerState::default();
+        s.active_overlay = Some(OverlayMode::Regular);
+        s.selected_param = 2;
+        s.apply_command(InputCommand::ParamValueDelta(5));
+        s.apply_command(InputCommand::ParamValueDelta(3));
+        assert!(matches!(
+            s.pending_edit,
+            PendingEdit::Param { overlay: OverlayMode::Regular, index: 2, value: 8 }
+        ));
+    }
+
+    #[test]
+    fn apply_command_param_value_delta_no_overlay_is_noop() {
+        let mut s = SequencerState::default();
+        // No overlay open
+        s.apply_command(InputCommand::ParamValueDelta(5));
+        assert!(matches!(s.pending_edit, PendingEdit::None));
+    }
+
+    #[test]
+    fn default_state_has_selected_step_0() {
+        let s = SequencerState::default();
+        assert_eq!(s.selected_step, 0);
+    }
+
+    #[test]
+    fn default_state_has_selected_param_0() {
+        let s = SequencerState::default();
+        assert_eq!(s.selected_param, 0);
     }
 }

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -95,10 +95,8 @@ fn update_local_overlay(ui: &mut UiState, cmd: &InputCommand) {
         InputCommand::OpenOverlay(mode) => {
             ui.overlay = Some(*mode);
         }
-        InputCommand::CloseOverlay | InputCommand::Confirm => {
-            if matches!(cmd, InputCommand::CloseOverlay) {
-                ui.overlay = None;
-            }
+        InputCommand::CloseOverlay => {
+            ui.overlay = None;
         }
         InputCommand::ParamSelectDelta(d) => {
             let current = ui.selected_param as i32;

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -1,0 +1,221 @@
+//! Keyboard UI event loop.
+//!
+//! Uses crossterm for raw terminal key events and ratatui for rendering.
+//! This module is gated behind the `hw-io` feature because crossterm and
+//! ratatui are optional dependencies.
+//!
+//! # Design: overlay state split
+//!
+//! `Option<OverlayMode>` and `selected_param: u8` live **in this UI thread
+//! only** — they are presentation state, not shared state.  The `PendingEdit`
+//! lives in `SequencerState` (shared) so the HID thread can read it.
+//!
+//! When the user presses F1/F2 the UI thread:
+//! 1. Sends `InputCommand::OpenOverlay(mode)` on the shared channel (so
+//!    `SequencerState::apply_command` records `active_overlay`).
+//! 2. Flips its own `overlay: Option<OverlayMode>` field to switch the key
+//!    mapping for subsequent events.
+//!
+//! This avoids a secondary back-channel from state → UI; the UI thread is the
+//! sole authority on the current overlay for key-mapping purposes.
+
+use std::sync::mpsc::SyncSender;
+use std::time::Duration;
+
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::Span;
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph};
+use ratatui::Terminal;
+
+use crate::input::{InputCommand, KeyCodeSimple, OverlayMode};
+use crate::input::{overlay_key_to_command, root_key_to_command};
+
+/// Regular overlay parameter names (index 0–6).
+const REGULAR_PARAMS: [&str; 7] = [
+    "Key",
+    "Mode",
+    "Swing",
+    "Step Size",
+    "Loop",
+    "Pause",
+    "Stop/Start",
+];
+
+/// Local UI state — lives entirely in the UI thread.
+struct UiState {
+    /// Active overlay, if any.  Tracked locally; not read from shared state.
+    overlay: Option<OverlayMode>,
+    /// Selected param index (0–6) — tracked locally for rendering.
+    selected_param: u8,
+}
+
+impl UiState {
+    fn new() -> Self {
+        Self { overlay: None, selected_param: 0 }
+    }
+}
+
+/// Convert a crossterm `KeyCode` into our portable `KeyCodeSimple`.
+fn to_simple(code: KeyCode) -> KeyCodeSimple {
+    match code {
+        KeyCode::Left => KeyCodeSimple::Left,
+        KeyCode::Right => KeyCodeSimple::Right,
+        KeyCode::Up => KeyCodeSimple::Up,
+        KeyCode::Down => KeyCodeSimple::Down,
+        KeyCode::Char(' ') => KeyCodeSimple::Space,
+        KeyCode::Enter => KeyCodeSimple::Enter,
+        KeyCode::Esc => KeyCodeSimple::Esc,
+        KeyCode::F(1) => KeyCodeSimple::F1,
+        KeyCode::F(2) => KeyCodeSimple::F2,
+        _ => KeyCodeSimple::Other,
+    }
+}
+
+/// Translate a crossterm `KeyEvent` into an `InputCommand`, given the current
+/// UI state (overlay open or not).  Returns `None` for unmapped keys.
+fn translate_key(event: KeyEvent, ui: &UiState) -> Option<InputCommand> {
+    let simple = to_simple(event.code);
+    let shift = event.modifiers.contains(KeyModifiers::SHIFT);
+
+    match ui.overlay {
+        None => root_key_to_command(simple, shift),
+        Some(_) => overlay_key_to_command(simple),
+    }
+}
+
+/// Apply overlay side-effects in the UI thread when a command is about to be sent.
+///
+/// The UI thread needs to track the overlay locally so subsequent key events
+/// are translated in the right mode.
+fn update_local_overlay(ui: &mut UiState, cmd: &InputCommand) {
+    match cmd {
+        InputCommand::OpenOverlay(mode) => {
+            ui.overlay = Some(*mode);
+        }
+        InputCommand::CloseOverlay | InputCommand::Confirm => {
+            if matches!(cmd, InputCommand::CloseOverlay) {
+                ui.overlay = None;
+            }
+        }
+        InputCommand::ParamSelectDelta(d) => {
+            let current = ui.selected_param as i32;
+            let next = ((current + *d as i32).rem_euclid(7)) as u8;
+            ui.selected_param = next;
+        }
+        InputCommand::ParamSelect(n) => {
+            ui.selected_param = *n;
+        }
+        _ => {}
+    }
+}
+
+/// Render the current state into the terminal.
+///
+/// This is a stub render that shows the overlay panel when active.
+fn render<B: ratatui::backend::Backend>(
+    terminal: &mut Terminal<B>,
+    ui: &UiState,
+) -> std::io::Result<()> {
+    terminal.draw(|frame| {
+        let area = frame.area();
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(3), Constraint::Length(5)])
+            .split(area);
+
+        // Top area — placeholder sequencer view.
+        let main_block = Block::default().title("MIDI-Man MK3").borders(Borders::ALL);
+        frame.render_widget(main_block, chunks[0]);
+
+        // Bottom area — overlay panel.
+        match ui.overlay {
+            None => {
+                let help = Paragraph::new("F1: Regular overlay  F2: Shift overlay  Space: Toggle  Enter: Confirm")
+                    .block(Block::default().title("Controls").borders(Borders::ALL));
+                frame.render_widget(help, chunks[1]);
+            }
+            Some(OverlayMode::Regular) => {
+                let items: Vec<ListItem> = REGULAR_PARAMS
+                    .iter()
+                    .enumerate()
+                    .map(|(i, name)| {
+                        if i as u8 == ui.selected_param {
+                            ListItem::new(Span::styled(
+                                format!("> {name}"),
+                                Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED),
+                            ))
+                        } else {
+                            ListItem::new(Span::raw(format!("  {name}")))
+                        }
+                    })
+                    .collect();
+                let list = List::new(items)
+                    .block(Block::default().title("Regular Overlay (Esc to close)").borders(Borders::ALL));
+                frame.render_widget(list, chunks[1]);
+            }
+            Some(OverlayMode::Shift) => {
+                let placeholder = Paragraph::new("(shift mode — coming soon)")
+                    .block(Block::default().title("Shift Overlay (Esc to close)").borders(Borders::ALL));
+                frame.render_widget(placeholder, chunks[1]);
+            }
+        }
+    })?;
+    Ok(())
+}
+
+/// Run the keyboard event loop.
+///
+/// Blocks until the user presses `q` or `Ctrl+C`.
+///
+/// `tx` is the shared command channel; both this function and the HID thread
+/// (Step 7) send `InputCommand` values on it.
+///
+/// Uses `crossterm::event::poll` with a 50 ms timeout so the render loop
+/// fires at ~20 FPS between key events.
+pub fn run(tx: SyncSender<InputCommand>) -> std::io::Result<()> {
+    use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
+    use crossterm::ExecutableCommand;
+    use std::io;
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    stdout.execute(EnterAlternateScreen)?;
+
+    let backend = CrosstermBackend::new(io::stdout());
+    let mut terminal = Terminal::new(backend)?;
+
+    let mut ui = UiState::new();
+    let mut running = true;
+
+    while running {
+        render(&mut terminal, &ui)?;
+
+        if event::poll(Duration::from_millis(50))? {
+            if let Event::Key(key_event) = event::read()? {
+                // Quit on 'q' or Ctrl+C.
+                if key_event.code == KeyCode::Char('q')
+                    || (key_event.code == KeyCode::Char('c')
+                        && key_event.modifiers.contains(KeyModifiers::CONTROL))
+                {
+                    running = false;
+                    continue;
+                }
+
+                if let Some(cmd) = translate_key(key_event, &ui) {
+                    update_local_overlay(&mut ui, &cmd);
+                    // Best-effort send; if the receiver is gone we exit cleanly.
+                    if tx.send(cmd).is_err() {
+                        running = false;
+                    }
+                }
+            }
+        }
+    }
+
+    disable_raw_mode()?;
+    stdout.execute(LeaveAlternateScreen)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- **`InputCommand` enum (11 variants) and canonical `OverlayMode`** defined in `engine/src/input.rs`; includes a feature-gate-free `KeyCodeSimple` mirror and two pure translation functions (`root_key_to_command`, `overlay_key_to_command`) unit-testable without `hw-io`.
- **`apply_command()` on `SequencerState`** in `engine/src/state.rs` handles all 11 variants with step wrapping (mod 16), note/velocity clamping (0–127), param wrapping (mod 7), `Confirm` commit semantics, and `CloseOverlay` discard. Added `selected_step`, `selected_param`, `pending_edit`, and `velocity` field to `StepData`.
- **Keyboard event loop in `ui.rs`** (`hw-io` gated) uses crossterm `event::poll` with 50 ms timeout for ~20 FPS render. Overlay state (`Option<OverlayMode>`, `selected_param`) tracked UI-thread-locally. Ratatui stub renders Regular overlay param list (highlighted selected param) and Shift overlay placeholder.
- **`hid.rs` `open_device()` non-fatal** — logs a warning to stderr and returns `None` instead of panicking when `HidApi::new()` or `open()` fails; engine continues with keyboard-only input.
- **BUG-004 fixed**: `tick()` now reads `step.velocity` instead of hardcoded 100; test updated to assert a non-default velocity.
- **BUG-005 fixed**: HID test `in_report_field_offsets_match_wire_spec` replaced `unsafe { std::mem::transmute }` with `std::mem::offset_of!` — no unsafe blocks remain in `hid.rs`.

## Key Architectural Decisions

- `SyncSender<InputCommand>` is the sole path into state mutation — HID reader (Step 7) and keyboard handler are peers on the same channel.
- Overlay presentation state (`Option<OverlayMode>`, `selected_param`) lives in the UI thread only; `PendingEdit` lives in `SequencerState` (shared, readable by HID thread).
- `OpenOverlay` is sent on the `InputCommand` channel; the UI thread inspects it in `update_local_overlay` before forwarding to `apply_command`.

## Test Coverage

- 164 tests total: 108 pre-existing + 19 keyboard-translation tests (`input::tests`) + 30 `apply_command` tests (`state::tests`) + 7 QA augmentation tests (velocity field, BUG-004 regression).
- All tests are unit tests. No external hardware required — `hw-io` feature gate excluded from test runs; `hidapi` and `crossterm` paths are not exercised in the test binary.
- `cargo test -p engine`: **164 passed, 0 failed**.

## Known Limitations / Follow-up

- HID-to-`InputCommand` translation (Step 7) is not yet implemented; `InReport` mapping will be a separate task.
- Regular overlay param semantics (Key, Mode, Swing, Step Size, Loop, Pause, Stop/Start) are stubbed in the render layer; functional param application is deferred to Step 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)