### PR TITLE
feat(engine): HID host reader/writer with InReport translation and LED OutReport

### DIFF
--- a/engine/src/hid.rs
+++ b/engine/src/hid.rs
@@ -307,6 +307,10 @@ pub fn run_hid(
     let mut buf = [0u8; 64];
 
     loop {
+        // Zero the buffer before each read so stale bytes from a prior
+        // short read cannot bleed into the current report's fields.
+        buf = [0u8; 64];
+
         let n = match device.read_timeout(&mut buf, 5) {
             Ok(n) => n,
             Err(e) => {
@@ -892,6 +896,28 @@ mod tests {
         assert!(matches!(cmds[2], InputCommand::StepSelect(3)));
         assert!(matches!(cmds[3], InputCommand::ToggleStep));
         assert!(matches!(cmds[4], InputCommand::ParamSelect(1)));
+    }
+
+    #[test]
+    fn translate_multiple_simultaneous_encoder_deltas_all_produce_commands() {
+        // Encoders 0, 7, and 15 all have non-zero deltas simultaneously.
+        // Each must produce a StepSelect + NoteDelta pair in index order.
+        let mut buf = [0u8; 64];
+        buf[9 + 0]  = 5i8 as u8;   // encoder_deltas[0]  = +5
+        buf[9 + 7]  = (-3i8) as u8; // encoder_deltas[7]  = -3
+        buf[9 + 15] = 1i8 as u8;   // encoder_deltas[15] = +1
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+
+        // Expect exactly 6 commands: (StepSelect(0), NoteDelta(5)),
+        // (StepSelect(7), NoteDelta(-3)), (StepSelect(15), NoteDelta(1)).
+        assert_eq!(cmds.len(), 6, "expected 6 commands for 3 encoder deltas, got {cmds:?}");
+        assert!(matches!(cmds[0], InputCommand::StepSelect(0)),  "cmds[0] should be StepSelect(0)");
+        assert!(matches!(cmds[1], InputCommand::NoteDelta(5)),   "cmds[1] should be NoteDelta(5)");
+        assert!(matches!(cmds[2], InputCommand::StepSelect(7)),  "cmds[2] should be StepSelect(7)");
+        assert!(matches!(cmds[3], InputCommand::NoteDelta(-3)),  "cmds[3] should be NoteDelta(-3)");
+        assert!(matches!(cmds[4], InputCommand::StepSelect(15)), "cmds[4] should be StepSelect(15)");
+        assert!(matches!(cmds[5], InputCommand::NoteDelta(1)),   "cmds[5] should be NoteDelta(1)");
     }
 
     // -----------------------------------------------------------------------

--- a/engine/src/hid.rs
+++ b/engine/src/hid.rs
@@ -19,6 +19,17 @@
 //   Byte  1   : sequence number echo
 //   Bytes 2-3  : led_state[15:0]
 //   Bytes 4-63 : reserved
+//
+// Translation note: overlay-aware routing (NoteDelta vs ParamValueDelta for
+// encoders when an overlay is open) is a future improvement. The HID thread
+// reads `state.active_overlay` to determine context; sending NoteDelta
+// unconditionally here is the stub behaviour documented in the task spec.
+
+use crate::input::{InputCommand, OverlayMode};
+#[cfg(feature = "hw-io")]
+use crate::state::SequencerState;
+#[cfg(feature = "hw-io")]
+use std::sync::{Arc, RwLock};
 
 /// USB Vendor ID — Raspberry Pi
 pub const HID_VID: u16 = 0x2E8A;
@@ -139,6 +150,247 @@ pub fn open_device() -> Option<hidapi::HidDevice> {
             );
             None
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure translation helpers — no hw-io dependency; fully unit-testable.
+// ---------------------------------------------------------------------------
+
+/// Translate one `InReport` into a sequence of `InputCommand` values.
+///
+/// Pure function: no I/O, no locks, no side effects.  The `active_overlay`
+/// argument is the current overlay state (read from shared state by the caller).
+///
+/// Param-button mapping (0-indexed from LSB of the two `param_buttons` bytes):
+/// - Bit 0  → OpenOverlay(Regular) + ParamSelect(0) (Key)
+/// - Bit 1  → ParamSelect(1) (Mode)
+/// - Bit 2  → ParamSelect(2) (Swing)
+/// - Bit 3  → ParamSelect(3) (Step Size)
+/// - Bits 4–7 → reserved (ignored)
+/// - Bit 8  → loop cycle: active_overlay determines in/out/clear cycling
+/// - Bit 9  → reserved (ignored)
+/// - Bit 10 → pause toggle (ParamValueDelta(1) stub — full state write in run_hid)
+/// - Bit 11 → stop/start toggle (handled via direct state write in run_hid)
+///
+/// Tempo delta and stop/start/pause are handled by `run_hid` with a write
+/// lock; they do NOT appear in the returned Vec.
+pub fn translate_in_report(
+    report: &InReport,
+    active_overlay: Option<OverlayMode>,
+) -> Vec<InputCommand> {
+    let mut cmds: Vec<InputCommand> = Vec::new();
+
+    // --- Encoder deltas (steps 0–15): note delta per step.
+    // Overlay-aware routing is a future improvement; always send NoteDelta.
+    for (i, &delta) in report.encoder_deltas.iter().enumerate() {
+        if delta != 0 {
+            // When an overlay is active the encoder controls param value;
+            // without overlay it controls the note for that step.
+            // Future: route to ParamValueDelta when overlay is open.
+            let _ = active_overlay; // suppress unused-variable lint
+            cmds.push(InputCommand::StepSelect(i));
+            cmds.push(InputCommand::NoteDelta(delta));
+        }
+    }
+
+    // --- Step buttons (bits 0–15 across two bytes).
+    let step_word = (report.step_buttons[0] as u16) | ((report.step_buttons[1] as u16) << 8);
+    for bit in 0..16u16 {
+        if step_word & (1 << bit) != 0 {
+            cmds.push(InputCommand::StepSelect(bit as usize));
+            cmds.push(InputCommand::ToggleStep);
+        }
+    }
+
+    // --- Param buttons (bits 0–11 across two bytes).
+    let param_word = (report.param_buttons[0] as u16) | ((report.param_buttons[1] as u16) << 8);
+
+    // Bits 0–3: overlay + param select.
+    // Bit 0: Key (index 0) — also opens overlay.
+    if param_word & (1 << 0) != 0 {
+        cmds.push(InputCommand::OpenOverlay(OverlayMode::Regular));
+        cmds.push(InputCommand::ParamSelect(0));
+    }
+    // Bits 1–3: Mode, Swing, Step Size (indices 1–3).
+    for idx in 1u8..=3 {
+        if param_word & (1 << idx) != 0 {
+            cmds.push(InputCommand::ParamSelect(idx));
+        }
+    }
+
+    // Bit 8: loop in/out/clear cycling.
+    // Loop cycle is a 3-state machine: set loop_in → set loop_out → clear.
+    // The HID thread advances the cycle by emitting ParamSelect(4) (loop param)
+    // + ParamValueDelta(1). Full loop-state machine lives in state.rs (future).
+    if param_word & (1 << 8) != 0 {
+        cmds.push(InputCommand::ParamSelect(4));
+        cmds.push(InputCommand::ParamValueDelta(1));
+    }
+
+    // Bit 9: reserved — ignored.
+
+    // Bit 10: pause toggle — emit ParamValueDelta on param index 5 (pause).
+    // Direct state mutation (paused flag) is performed by run_hid under write lock.
+    if param_word & (1 << 10) != 0 {
+        cmds.push(InputCommand::ParamSelect(5));
+        cmds.push(InputCommand::ParamValueDelta(1));
+    }
+
+    // Bit 11: stop/start — direct state mutation in run_hid; no InputCommand emitted.
+    // (The playing flag toggle is a direct write, not expressible as InputCommand yet.)
+
+    // --- Param knob delta.
+    if report.param_knob_delta != 0 {
+        cmds.push(InputCommand::ParamValueDelta(report.param_knob_delta));
+    }
+
+    cmds
+}
+
+/// Compute the two LED state bytes from the current step-enable bitmap.
+///
+/// `steps_enabled[i]` is `true` if step `i` is enabled.  Bit `i` of the
+/// returned `[u8; 2]` reflects `steps_enabled[i]`.
+pub fn compute_led_bytes(steps_enabled: &[bool; 16]) -> [u8; 2] {
+    let mut lo: u8 = 0;
+    let mut hi: u8 = 0;
+    for i in 0..8 {
+        if steps_enabled[i] {
+            lo |= 1 << i;
+        }
+        if steps_enabled[i + 8] {
+            hi |= 1 << (i);
+        }
+    }
+    [lo, hi]
+}
+
+// ---------------------------------------------------------------------------
+// Hardware I/O — only compiled with the `hw-io` feature.
+// ---------------------------------------------------------------------------
+
+/// Run the HID host read/translate/write loop.
+///
+/// Opens the Pico HID device by VID/PID.  If the device is not found, logs a
+/// warning and returns immediately without panicking.  Otherwise, polls for
+/// `InReport` data in a 5 ms timeout loop, translates each report into
+/// `InputCommand` values sent on `cmd_tx`, writes back an `OutReport` with
+/// the current LED state, and sends on `ui_notify` to wake the UI thread.
+///
+/// The thread exits cleanly when `cmd_tx` becomes disconnected.
+#[cfg(feature = "hw-io")]
+pub fn run_hid(
+    cmd_tx: std::sync::mpsc::SyncSender<InputCommand>,
+    state: Arc<RwLock<SequencerState>>,
+    ui_notify: std::sync::mpsc::SyncSender<()>,
+) {
+    use hidapi::HidApi;
+
+    let api = match HidApi::new() {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("[hid] hidapi init failed: {e}; HID thread exiting");
+            return;
+        }
+    };
+
+    let device = match api.open(HID_VID, HID_PID) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("[hid] device {HID_VID:#06x}:{HID_PID:#06x} not found: {e}; HID thread exiting");
+            return;
+        }
+    };
+
+    let mut last_seq: Option<u8> = None;
+    let mut buf = [0u8; 64];
+
+    loop {
+        let n = match device.read_timeout(&mut buf, 5) {
+            Ok(n) => n,
+            Err(e) => {
+                eprintln!("[hid] read error: {e}; HID thread exiting");
+                return;
+            }
+        };
+
+        if n == 0 {
+            // Timeout — no data this cycle.
+            continue;
+        }
+
+        let report = InReport::from_bytes(&buf);
+
+        // Sequence-number duplicate check.
+        if let Some(prev) = last_seq {
+            if prev == report.seq {
+                eprintln!("[hid] duplicate sequence number {}: possible stale report", report.seq);
+            }
+        }
+        last_seq = Some(report.seq);
+
+        // --- Direct state writes (tempo, pause, stop/start). ---
+        let param_word = (report.param_buttons[0] as u16) | ((report.param_buttons[1] as u16) << 8);
+        {
+            let mut st = state.write().expect("hid: state write lock poisoned");
+
+            // Tempo delta — direct write, clamped to 20–300 BPM.
+            if report.tempo_delta != 0 {
+                let new_bpm = (st.tempo_bpm as i32 + report.tempo_delta as i32)
+                    .clamp(20, 300) as u16;
+                st.tempo_bpm = new_bpm;
+            }
+
+            // Bit 10: pause toggle.
+            if param_word & (1 << 10) != 0 {
+                st.paused = !st.paused;
+            }
+
+            // Bit 11: stop/start toggle.
+            if param_word & (1 << 11) != 0 {
+                st.playing = !st.playing;
+                if !st.playing {
+                    st.paused = false;
+                    st.playhead = 0;
+                }
+            }
+        }
+
+        // Read active_overlay for translation context.
+        let active_overlay = state.read().expect("hid: state read lock poisoned").active_overlay;
+
+        // --- Translate to InputCommand and send. ---
+        let cmds = translate_in_report(&report, active_overlay);
+        for cmd in cmds {
+            if cmd_tx.send(cmd).is_err() {
+                // Receiver dropped — engine is shutting down.
+                return;
+            }
+        }
+
+        // --- Build and write OutReport (LED state). ---
+        {
+            let st = state.read().expect("hid: state read lock poisoned");
+            let mut enabled = [false; 16];
+            for (i, step) in st.steps.iter().enumerate() {
+                enabled[i] = step.enabled;
+            }
+            let led_bytes = compute_led_bytes(&enabled);
+            let out = OutReport {
+                report_id: 0x02,
+                seq_echo: report.seq,
+                led_state: led_bytes,
+                reserved: [0u8; 60],
+            };
+            let out_buf = out.to_bytes();
+            if let Err(e) = device.write(&out_buf) {
+                eprintln!("[hid] write error: {e}");
+            }
+        }
+
+        // Wake the UI thread.
+        let _ = ui_notify.send(());
     }
 }
 
@@ -484,5 +736,218 @@ mod tests {
         let buf = report.to_bytes();
         assert_eq!(buf[2], 0b1010_1010, "led_state[0] alternating pattern must be preserved");
         assert_eq!(buf[3], 0b0101_0101, "led_state[1] alternating pattern must be preserved");
+    }
+
+    // -----------------------------------------------------------------------
+    // translate_in_report — pure translation logic tests (no hw-io needed).
+    // -----------------------------------------------------------------------
+
+    /// Build a zeroed InReport for easy field-level mutation in tests.
+    fn zero_report() -> InReport {
+        InReport::from_bytes(&[0u8; 64])
+    }
+
+    #[test]
+    fn translate_encoder_delta_step0_emits_step_select_and_note_delta() {
+        let mut buf = [0u8; 64];
+        buf[9] = 3i8 as u8; // encoder_deltas[0] = +3
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+
+        // Should see StepSelect(0) then NoteDelta(3).
+        let mut iter = cmds.iter();
+        assert!(matches!(iter.next(), Some(InputCommand::StepSelect(0))));
+        assert!(matches!(iter.next(), Some(InputCommand::NoteDelta(3))));
+    }
+
+    #[test]
+    fn translate_encoder_delta_negative_emits_correct_delta() {
+        let mut buf = [0u8; 64];
+        buf[9 + 5] = (-2i8) as u8; // encoder_deltas[5] = -2
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+
+        assert!(matches!(cmds[0], InputCommand::StepSelect(5)));
+        assert!(matches!(cmds[1], InputCommand::NoteDelta(-2)));
+    }
+
+    #[test]
+    fn translate_zero_encoder_deltas_produces_no_encoder_commands() {
+        let report = zero_report();
+        let cmds = translate_in_report(&report, None);
+        // With all-zero input, no commands should be produced.
+        assert!(cmds.is_empty(), "expected no commands for zeroed report, got {cmds:?}");
+    }
+
+    #[test]
+    fn translate_step_button_bit3_emits_step_select_and_toggle() {
+        let mut buf = [0u8; 64];
+        buf[3] = 0b0000_1000; // step_buttons low: bit 3 set → step 3
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+
+        assert_eq!(cmds.len(), 2, "expected StepSelect + ToggleStep");
+        assert!(matches!(cmds[0], InputCommand::StepSelect(3)));
+        assert!(matches!(cmds[1], InputCommand::ToggleStep));
+    }
+
+    #[test]
+    fn translate_step_button_high_byte_bit_emits_correct_step_index() {
+        // Step 9 = bit 1 of the high byte (buf[4]).
+        let mut buf = [0u8; 64];
+        buf[4] = 0b0000_0010; // bit 9 overall
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+
+        assert_eq!(cmds.len(), 2);
+        assert!(matches!(cmds[0], InputCommand::StepSelect(9)));
+        assert!(matches!(cmds[1], InputCommand::ToggleStep));
+    }
+
+    #[test]
+    fn translate_param_button_bit0_opens_overlay_and_selects_param0() {
+        let mut buf = [0u8; 64];
+        buf[7] = 0b0000_0001; // param_buttons[0] bit 0 = Key
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+
+        assert_eq!(cmds.len(), 2);
+        assert!(matches!(cmds[0], InputCommand::OpenOverlay(OverlayMode::Regular)));
+        assert!(matches!(cmds[1], InputCommand::ParamSelect(0)));
+    }
+
+    #[test]
+    fn translate_param_button_bit1_selects_param1() {
+        let mut buf = [0u8; 64];
+        buf[7] = 0b0000_0010; // bit 1 = Mode
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+
+        assert_eq!(cmds.len(), 1);
+        assert!(matches!(cmds[0], InputCommand::ParamSelect(1)));
+    }
+
+    #[test]
+    fn translate_param_button_bit8_emits_loop_param_cycle() {
+        // Bit 8 = byte index 1 (buf[8]), bit 0 of that byte.
+        let mut buf = [0u8; 64];
+        buf[8] = 0b0000_0001; // param_buttons high byte bit 0 = overall bit 8
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+
+        assert_eq!(cmds.len(), 2);
+        assert!(matches!(cmds[0], InputCommand::ParamSelect(4)));
+        assert!(matches!(cmds[1], InputCommand::ParamValueDelta(1)));
+    }
+
+    #[test]
+    fn translate_param_button_bit10_emits_pause_param_cycle() {
+        // Bit 10 = buf[8] bit 2.
+        let mut buf = [0u8; 64];
+        buf[8] = 0b0000_0100;
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+
+        assert_eq!(cmds.len(), 2);
+        assert!(matches!(cmds[0], InputCommand::ParamSelect(5)));
+        assert!(matches!(cmds[1], InputCommand::ParamValueDelta(1)));
+    }
+
+    #[test]
+    fn translate_param_button_bit11_emits_no_input_command() {
+        // Bit 11 = buf[8] bit 3. Stop/start handled by direct state write in run_hid.
+        let mut buf = [0u8; 64];
+        buf[8] = 0b0000_1000;
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+        // bit11 alone should produce no InputCommand entries.
+        assert!(cmds.is_empty(), "stop/start should not emit InputCommand, got {cmds:?}");
+    }
+
+    #[test]
+    fn translate_param_knob_delta_emits_param_value_delta() {
+        let mut buf = [0u8; 64];
+        buf[26] = 7i8 as u8; // param_knob_delta = +7
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+
+        assert_eq!(cmds.len(), 1);
+        assert!(matches!(cmds[0], InputCommand::ParamValueDelta(7)));
+    }
+
+    #[test]
+    fn translate_synthetic_full_report_encoder_step_param() {
+        // Encoder delta on step 0, step button 3 press, param button 1 press.
+        let mut buf = [0u8; 64];
+        buf[9] = 1i8 as u8;    // encoder_deltas[0] = +1
+        buf[3] = 0b0000_1000;  // step_buttons bit 3 = step 3
+        buf[7] = 0b0000_0010;  // param_buttons bit 1 = Mode
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+
+        // Expected: StepSelect(0), NoteDelta(1), StepSelect(3), ToggleStep, ParamSelect(1).
+        assert_eq!(cmds.len(), 5, "expected 5 commands, got {cmds:?}");
+        assert!(matches!(cmds[0], InputCommand::StepSelect(0)));
+        assert!(matches!(cmds[1], InputCommand::NoteDelta(1)));
+        assert!(matches!(cmds[2], InputCommand::StepSelect(3)));
+        assert!(matches!(cmds[3], InputCommand::ToggleStep));
+        assert!(matches!(cmds[4], InputCommand::ParamSelect(1)));
+    }
+
+    // -----------------------------------------------------------------------
+    // compute_led_bytes — LED bit packing tests.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn compute_led_bytes_all_enabled_returns_ff_ff() {
+        let enabled = [true; 16];
+        assert_eq!(compute_led_bytes(&enabled), [0xFF, 0xFF]);
+    }
+
+    #[test]
+    fn compute_led_bytes_all_disabled_returns_00_00() {
+        let enabled = [false; 16];
+        assert_eq!(compute_led_bytes(&enabled), [0x00, 0x00]);
+    }
+
+    #[test]
+    fn compute_led_bytes_only_step0_sets_lo_bit0() {
+        let mut enabled = [false; 16];
+        enabled[0] = true;
+        let [lo, hi] = compute_led_bytes(&enabled);
+        assert_eq!(lo, 0b0000_0001, "step 0 should set bit 0 of lo byte");
+        assert_eq!(hi, 0x00);
+    }
+
+    #[test]
+    fn compute_led_bytes_only_step8_sets_hi_bit0() {
+        let mut enabled = [false; 16];
+        enabled[8] = true;
+        let [lo, hi] = compute_led_bytes(&enabled);
+        assert_eq!(lo, 0x00);
+        assert_eq!(hi, 0b0000_0001, "step 8 should set bit 0 of hi byte");
+    }
+
+    #[test]
+    fn compute_led_bytes_only_step15_sets_hi_bit7() {
+        let mut enabled = [false; 16];
+        enabled[15] = true;
+        let [lo, hi] = compute_led_bytes(&enabled);
+        assert_eq!(lo, 0x00);
+        assert_eq!(hi, 0b1000_0000, "step 15 should set bit 7 of hi byte");
+    }
+
+    #[test]
+    fn compute_led_bytes_alternating_steps_match_expected_pattern() {
+        let mut enabled = [false; 16];
+        // Enable even steps: 0, 2, 4, 6, 8, 10, 12, 14.
+        for i in (0..16).step_by(2) {
+            enabled[i] = true;
+        }
+        let [lo, hi] = compute_led_bytes(&enabled);
+        // Steps 0, 2, 4, 6 → bits 0, 2, 4, 6 of lo.
+        assert_eq!(lo, 0b0101_0101);
+        // Steps 8, 10, 12, 14 → bits 0, 2, 4, 6 of hi.
+        assert_eq!(hi, 0b0101_0101);
     }
 }

--- a/engine/src/hid.rs
+++ b/engine/src/hid.rs
@@ -976,4 +976,96 @@ mod tests {
         // Steps 8, 10, 12, 14 → bits 0, 2, 4, 6 of hi.
         assert_eq!(hi, 0b0101_0101);
     }
+
+    #[test]
+    fn compute_led_bytes_only_step7_sets_lo_bit7() {
+        // Step 7 is the MSB of the low byte; byte 0 must be 0x80, byte 1 = 0x00.
+        let mut enabled = [false; 16];
+        enabled[7] = true;
+        let [lo, hi] = compute_led_bytes(&enabled);
+        assert_eq!(lo, 0x80, "step 7 should set bit 7 (MSB) of lo byte → 0x80");
+        assert_eq!(hi, 0x00, "hi byte must be 0x00 when only step 7 is enabled");
+    }
+
+    // -----------------------------------------------------------------------
+    // translate_in_report — additional edge cases required by QA task.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn translate_all_zero_report_emits_no_commands() {
+        // An InReport where every field is zero must produce an empty command list.
+        // This covers: zero encoder deltas, no step buttons pressed, no param buttons,
+        // zero tempo_delta, zero param_knob_delta.
+        let report = InReport::from_bytes(&[0u8; 64]);
+        let cmds = translate_in_report(&report, None);
+        assert!(cmds.is_empty(), "all-zero InReport must emit no InputCommands, got {cmds:?}");
+    }
+
+    #[test]
+    fn translate_all_16_step_buttons_set_emits_32_commands() {
+        // All 16 step_buttons bits set → 16 × (StepSelect(i) + ToggleStep) pairs,
+        // in ascending index order 0..=15.
+        let mut buf = [0u8; 64];
+        buf[3] = 0xFF; // step_buttons low byte: steps 0–7
+        buf[4] = 0xFF; // step_buttons high byte: steps 8–15
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+
+        assert_eq!(cmds.len(), 32, "expected 32 commands (16 × StepSelect+ToggleStep), got {cmds:?}");
+        for i in 0..16usize {
+            assert!(
+                matches!(cmds[i * 2], InputCommand::StepSelect(s) if s == i),
+                "cmds[{}] should be StepSelect({i}), got {:?}", i * 2, cmds[i * 2]
+            );
+            assert!(
+                matches!(cmds[i * 2 + 1], InputCommand::ToggleStep),
+                "cmds[{}] should be ToggleStep, got {:?}", i * 2 + 1, cmds[i * 2 + 1]
+            );
+        }
+    }
+
+    #[test]
+    fn translate_param_buttons_bits_0_1_2_3_all_set_emits_correct_commands() {
+        // param_buttons bits 0–3 all set simultaneously.
+        // Bit 0 → OpenOverlay(Regular) + ParamSelect(0)
+        // Bit 1 → ParamSelect(1)
+        // Bit 2 → ParamSelect(2)
+        // Bit 3 → ParamSelect(3)
+        let mut buf = [0u8; 64];
+        buf[7] = 0b0000_1111; // bits 0, 1, 2, 3 set
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, None);
+
+        // Expected order: OpenOverlay(Regular), ParamSelect(0), ParamSelect(1),
+        // ParamSelect(2), ParamSelect(3) — 5 total.
+        assert_eq!(cmds.len(), 5, "expected 5 commands for bits 0–3, got {cmds:?}");
+        assert!(matches!(cmds[0], InputCommand::OpenOverlay(OverlayMode::Regular)),
+            "cmds[0] should be OpenOverlay(Regular)");
+        assert!(matches!(cmds[1], InputCommand::ParamSelect(0)),
+            "cmds[1] should be ParamSelect(0)");
+        assert!(matches!(cmds[2], InputCommand::ParamSelect(1)),
+            "cmds[2] should be ParamSelect(1)");
+        assert!(matches!(cmds[3], InputCommand::ParamSelect(2)),
+            "cmds[3] should be ParamSelect(2)");
+        assert!(matches!(cmds[4], InputCommand::ParamSelect(3)),
+            "cmds[4] should be ParamSelect(3)");
+    }
+
+    #[test]
+    fn translate_encoder_delta_with_active_overlay_emits_note_delta_not_param_value_delta() {
+        // Documents current behaviour: overlay-aware routing is deferred.
+        // Even with active_overlay = Some(Regular), translate_in_report always
+        // emits StepSelect + NoteDelta, never ParamValueDelta, for encoder inputs.
+        // This test records the current (stub) behaviour so a future change is visible.
+        let mut buf = [0u8; 64];
+        buf[9 + 3] = 2i8 as u8; // encoder_deltas[3] = +2
+        let report = InReport::from_bytes(&buf);
+        let cmds = translate_in_report(&report, Some(OverlayMode::Regular));
+
+        assert_eq!(cmds.len(), 2, "expected exactly 2 commands, got {cmds:?}");
+        assert!(matches!(cmds[0], InputCommand::StepSelect(3)),
+            "cmds[0] should be StepSelect(3) regardless of overlay; got {:?}", cmds[0]);
+        assert!(matches!(cmds[1], InputCommand::NoteDelta(2)),
+            "cmds[1] should be NoteDelta(2) — overlay-aware routing is deferred; got {:?}", cmds[1]);
+    }
 }


### PR DESCRIPTION
## Summary

- **`run_hid()`**: Full read/translate/write loop gated under `#[cfg(feature = \"hw-io\")]`. Opens HID device by VID/PID; on open failure logs a warning and returns immediately (non-fatal). Inner loop uses `device.read_timeout(&mut buf, 5)` for a 5 ms non-blocking poll, checks consecutive sequence numbers for duplicates, translates each `InReport` into `InputCommand` values sent on `cmd_tx`, acquires a read lock on `SequencerState` to compute LED state, writes an `OutReport`, and signals `ui_notify`. Loop exits cleanly when `cmd_tx` is disconnected.

- **`translate_in_report(report, active_overlay) -> Vec<InputCommand>`**: Pure function (no hw-io dependency). Maps `encoder_deltas[i] != 0` → `StepSelect(i) + NoteDelta(delta)`; `step_buttons` bit i → `StepSelect(i) + ToggleStep`; `param_buttons` bit 0 → `OpenOverlay(Regular) + ParamSelect(0)`; bits 1–3 → `ParamSelect(1..3)`; bit 8 (loop) → `ParamSelect(4) + ParamValueDelta(1)`; bit 10 (pause) → `ParamSelect(5) + ParamValueDelta(1)`; bit 11 (stop/start) → direct state write (no InputCommand emitted); `param_knob_delta != 0` → `ParamValueDelta(param_knob_delta)`; `tempo_delta != 0` → direct `state.tempo_bpm` write under write lock.

- **`compute_led_bytes(steps_enabled) -> [u8; 2]`**: Pure function packing `steps[i].enabled` into a 2-byte LED bitmask. Bit i of byte 0 = step i (0–7); bit i of byte 1 = step i+8 (8–15). Mirrors `OutReport.led_state` wire layout exactly.

- **BUG-006 fixed**: `buf = [0u8; 64];` is now the first statement inside the `run_hid` loop body, zeroing the buffer before every `read_timeout` call. Prevents stale bytes from short reads bleeding into `InReport::from_bytes` and silently mixing fields from two different reports.

- **Overlay-aware encoder routing deferred**: `translate_in_report` always emits `StepSelect + NoteDelta` regardless of `active_overlay`. The `ParamValueDelta` path is documented in code comments as a future improvement; the deferred behavior is explicitly asserted by test `translate_encoder_delta_with_active_overlay_emits_note_delta_not_param_value_delta`.

## Test Coverage

188 tests passing (164 baseline + 24 new in `engine/src/hid.rs`). All tests are pure unit tests; `run_hid` itself is gated behind `hw-io` and tested via `translate_in_report` and `compute_led_bytes` as pure functions. No external hardware or HID device required to run the suite.

Key new tests include: synthetic full-report round-trip (`translate_synthetic_full_report_encoder_step_param`), simultaneous multi-encoder deltas on steps 0/7/15, all-16-step-buttons-set producing 32 commands in order, `compute_led_bytes` boundary cases (step 7 at MSB edge of byte 0, step 8 at LSB edge of byte 1), and the deferred-overlay assertion documenting the `NoteDelta`-always behavior.

## Known Limitations / Follow-up

- Overlay-aware encoder routing (emit `ParamValueDelta` when `active_overlay.is_some()`) is deferred; task spec explicitly marks this as future work.
- Loop button (bit 8) emits a simple `ParamSelect(4) + ParamValueDelta(1)` cycle increment; full 3-state in/out/clear machine is deferred to a future `state.rs` enhancement.
- `RwLock` poison is handled by `expect()` with a message (compliant with code standards); lock poisoning only occurs if another thread panicked while holding the write lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)