### PR TITLE
feat: interactive MIDI port selection on startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Rust
+target/
+**/*.rs.bk
+Cargo.lock.bak
+
 # Agent worktrees (created and destroyed at runtime)
 .workflow/worktrees/*
 !.workflow/worktrees/.gitkeep

--- a/README.md
+++ b/README.md
@@ -74,13 +74,24 @@ cargo build -p engine --features hw-io
 cargo run -p engine --features hw-io --release
 ```
 
-### Specifying a MIDI port or custom HID VID/PID
+On startup the engine lists all available ALSA MIDI output ports and prompts you to select one:
 
 ```
-cargo run -p engine --features hw-io --release -- --midi-port "UM-ONE" --hid-vid 0xCAFE --hid-pid 0x4004
+Available MIDI output ports:
+  [0] Midi Through:Midi Through Port-0 14:0
+  [1] UM-ONE:UM-ONE MIDI 1 20:0
+Select port [0]:
 ```
 
-- `--midi-port <name>` — substring match against available ALSA MIDI ports; defaults to the first port found
+Press Enter to accept the default, or type a number and press Enter. If only one port is available it is selected automatically.
+
+### Skip the prompt with a port filter
+
+```
+cargo run -p engine --features hw-io --release -- --midi-port "UM-ONE"
+```
+
+- `--midi-port <name>` — substring match against available ALSA MIDI ports; bypasses the interactive prompt
 - `--hid-vid <hex>` — USB vendor ID of the controller (default `0xCAFE`)
 - `--hid-pid <hex>` — USB product ID of the controller (default `0x4004`)
 

--- a/engine/src/midi_out.rs
+++ b/engine/src/midi_out.rs
@@ -80,12 +80,44 @@ pub fn select_port_idx(port_names: &[&str], filter: Option<&str>) -> Option<usiz
     }
 }
 
+/// Interactively prompt the user to choose a MIDI port by number.
+///
+/// Prints a numbered list to stdout and reads a line from stdin.
+/// Returns the chosen index, or 0 on invalid input.
+#[cfg(feature = "hw-io")]
+fn prompt_port_selection(port_names: &[String]) -> usize {
+    println!("\nAvailable MIDI output ports:");
+    for (i, name) in port_names.iter().enumerate() {
+        println!("  [{i}] {name}");
+    }
+    print!("Select port [0]: ");
+    // Flush so the prompt appears before blocking on input.
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
+
+    let mut line = String::new();
+    if std::io::stdin().read_line(&mut line).is_ok() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            return 0;
+        }
+        if let Ok(n) = trimmed.parse::<usize>() {
+            if n < port_names.len() {
+                return n;
+            }
+        }
+        eprintln!("[midi_out] invalid selection '{trimmed}' — using port 0");
+    }
+    0
+}
+
 /// Open an ALSA MIDI output port.
 ///
 /// When `port_name` is `Some(filter)`, searches for a port whose name contains
-/// `filter` (case-insensitive substring match).  If no matching port is found,
-/// logs a warning and falls back to the first available port.  When `port_name`
-/// is `None`, opens the first available port.
+/// `filter` (case-insensitive substring match) and opens it without prompting.
+/// When `port_name` is `None` and only one port exists, opens it automatically.
+/// When `port_name` is `None` and multiple ports exist, prompts the user to
+/// select one interactively.
 ///
 /// Returns `None` if no ports are available or if opening the chosen port fails.
 #[cfg(feature = "hw-io")]
@@ -104,27 +136,34 @@ fn open_port(port_name: Option<&str>) -> Option<Box<dyn MidiSender>> {
         return None;
     }
 
-    // Collect port names so select_port_idx can operate on plain string slices.
     let port_name_strings: Vec<String> = ports.iter()
         .map(|p| output.port_name(p).unwrap_or_default())
         .collect();
     let port_name_refs: Vec<&str> = port_name_strings.iter().map(String::as_str).collect();
 
-    // Determine which port to open using the pure selection helper.
-    let chosen_idx = select_port_idx(&port_name_refs, port_name)
-        .expect("ports is non-empty; select_port_idx always returns Some for non-empty slice");
+    let chosen_idx = if let Some(filter) = port_name {
+        // --midi-port supplied: use substring match, no prompt.
+        select_port_idx(&port_name_refs, Some(filter))
+            .expect("ports is non-empty")
+    } else if ports.len() == 1 {
+        // Only one port — auto-select without prompting.
+        println!("[midi_out] one port found, auto-selecting: {}", port_name_strings[0]);
+        0
+    } else {
+        // Multiple ports and no filter — ask the user.
+        prompt_port_selection(&port_name_strings)
+    };
 
     let port = &ports[chosen_idx];
     let chosen_name = output.port_name(port).unwrap_or_else(|_| "<unknown>".to_owned());
-    println!("[midi_out] opening port: {chosen_name}");
 
     match output.connect(port, "midi-man-mk3-out") {
         Ok(conn) => {
-            println!("[midi_out] connected to port: {chosen_name}");
+            println!("[midi_out] connected to: {chosen_name}");
             Some(Box::new(MidirSender { conn: Arc::new(Mutex::new(conn)) }))
         }
         Err(e) => {
-            eprintln!("[midi_out] failed to connect to port '{chosen_name}': {e}");
+            eprintln!("[midi_out] failed to connect to '{chosen_name}': {e}");
             None
         }
     }


### PR DESCRIPTION
## Summary

- On startup with multiple MIDI ports available, enumerate them with numbers and prompt the user to select one interactively
- Single-port systems auto-select without prompting
- `--midi-port <filter>` bypasses the prompt entirely for scripted/headless use

## Test plan

- [ ] Run with no MIDI devices connected — should print "no ports available" and disable MIDI output
- [ ] Run with one MIDI device connected — should auto-select and print the port name
- [ ] Run with multiple MIDI devices connected — should print numbered list and prompt
- [ ] Run with `--midi-port <name>` — should skip prompt and connect directly
- [ ] `cargo test -p engine` passes (249 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)