### PR TITLE
fix: BUG-013/015/016 — remove dead open_device(), add MIDI filter warning, fix config.toml comment

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,8 +4,9 @@
 #
 # Local developer overrides (gitignored):
 # If your system is missing alsa-lib-devel, create .cargo/config.local.toml
-# with the following content and point Cargo at it via CARGO_CONFIG_TOML
-# or by temporarily editing this file (do not commit those changes):
+# with the following content and activate it via:
+#   cargo build --config .cargo/config.local.toml
+# or temporarily edit this file (do not commit those changes):
 #
 #   # .cargo/config.local.toml  (gitignored)
 #   [env]

--- a/engine/src/hid.rs
+++ b/engine/src/hid.rs
@@ -127,32 +127,6 @@ impl OutReport {
     }
 }
 
-/// Non-fatal HID device opener.
-///
-/// Returns `Some(device)` when the device is found and opened, or `None` when
-/// it is unavailable.  Errors are logged to stderr so the engine can continue
-/// with keyboard-only input.
-#[cfg(feature = "hw-io")]
-pub fn open_device() -> Option<hidapi::HidDevice> {
-    let api = match hidapi::HidApi::new() {
-        Ok(a) => a,
-        Err(e) => {
-            eprintln!("warn: hidapi init failed ({e}) — running without HID device");
-            return None;
-        }
-    };
-    match api.open(HID_VID, HID_PID) {
-        Ok(dev) => Some(dev),
-        Err(e) => {
-            eprintln!(
-                "warn: could not open HID device {:04X}:{:04X} ({e}) — running without HID device",
-                HID_VID, HID_PID
-            );
-            None
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Pure translation helpers — no hw-io dependency; fully unit-testable.
 // ---------------------------------------------------------------------------

--- a/engine/src/midi_out.rs
+++ b/engine/src/midi_out.rs
@@ -130,6 +130,9 @@ pub fn choose_midi_port(filter: Option<&str>) -> Option<String> {
     if let Some(f) = filter {
         let f_lower = f.to_lowercase();
         let matched = names.iter().find(|n| n.to_lowercase().contains(&f_lower));
+        if matched.is_none() {
+            eprintln!("[midi] port filter {:?} matched no ports; falling back to port 0", f);
+        }
         return Some(matched.unwrap_or(&names[0]).clone());
     }
 

--- a/engine/tests/cargo_config.rs
+++ b/engine/tests/cargo_config.rs
@@ -2,11 +2,14 @@
 /// values in `.cargo/config.toml`, and `.gitignore` must contain the entry for
 /// the gitignored local-override file.
 ///
+/// BUG-013 acceptance tests: .cargo/config.toml comment must reference the
+/// correct `--config` invocation, not the non-existent CARGO_CONFIG_TOML env var.
+///
 /// `CARGO_MANIFEST_DIR` is set by Cargo to the engine crate root at test time.
 /// The workspace root (where `.cargo/config.toml` and `.gitignore` live) is one
 /// directory above.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Return the workspace root directory (one level above the engine crate root).
 fn workspace_root() -> PathBuf {
@@ -36,6 +39,13 @@ fn full_cargo_config() -> String {
     let path = workspace_root().join(".cargo/config.toml");
     std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
+}
+
+fn read_cargo_config() -> String {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let config_path = Path::new(manifest_dir).join("..").join(".cargo").join("config.toml");
+    std::fs::read_to_string(&config_path)
+        .unwrap_or_else(|e| panic!("cannot read .cargo/config.toml at {}: {e}", config_path.display()))
 }
 
 /// Read the full text of `.gitignore`.
@@ -101,5 +111,32 @@ fn cargo_config_documents_local_override_pattern() {
     assert!(
         contents.contains(".cargo/config.local.toml"),
         ".cargo/config.toml must mention '.cargo/config.local.toml' in a comment to document the local-override pattern for developers"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// BUG-013 – .cargo/config.toml must not reference CARGO_CONFIG_TOML env var
+// ---------------------------------------------------------------------------
+
+/// The non-existent `CARGO_CONFIG_TOML` environment variable must not appear
+/// in .cargo/config.toml. Before BUG-013 was fixed the developer comment
+/// incorrectly told users to set this env var.
+#[test]
+fn cargo_config_toml_does_not_reference_cargo_config_toml_env_var() {
+    let content = read_cargo_config();
+    assert!(
+        !content.contains("CARGO_CONFIG_TOML"),
+        ".cargo/config.toml must not reference the non-existent CARGO_CONFIG_TOML env var (BUG-013)"
+    );
+}
+
+/// After BUG-013 was fixed, the comment must document the correct invocation:
+/// `--config .cargo/config.local.toml`.
+#[test]
+fn cargo_config_toml_references_config_local_toml_flag() {
+    let content = read_cargo_config();
+    assert!(
+        content.contains("--config .cargo/config.local.toml"),
+        ".cargo/config.toml must contain '--config .cargo/config.local.toml' (BUG-013)"
     );
 }

--- a/engine/tests/hid.rs
+++ b/engine/tests/hid.rs
@@ -637,3 +637,21 @@ fn translate_encoder_delta_with_active_overlay_emits_note_delta_not_param_value_
     assert!(matches!(cmds[1], InputCommand::NoteDelta(2)),
         "cmds[1] should be NoteDelta(2) — overlay-aware routing is deferred; got {:?}", cmds[1]);
 }
+
+// -----------------------------------------------------------------------
+// BUG-015: open_device() is gone — only constants remain.
+// -----------------------------------------------------------------------
+
+/// `HID_VID` and `HID_PID` constants are still exported after `open_device()` was
+/// removed (BUG-015). Callers use these constants as default arguments to `run_hid`.
+///
+/// Note: attempting to import `engine::hid::open_device` on this branch would
+/// produce a compile error (`use of undeclared crate or module item`), which is the
+/// intended proof that dead code was removed.  A `compile_fail` doc-test would be
+/// the canonical form; we document the intent here instead.
+#[test]
+fn hid_vid_pid_constants_still_exported_after_open_device_removal() {
+    // HID_VID and HID_PID must remain accessible — they are used by run_hid callers.
+    assert_eq!(HID_VID, 0x2E8A, "HID_VID must still be 0x2E8A after open_device removal");
+    assert_eq!(HID_PID, 0x000A, "HID_PID must still be 0x000A after open_device removal");
+}

--- a/engine/tests/midi_out.rs
+++ b/engine/tests/midi_out.rs
@@ -319,3 +319,54 @@ fn select_port_idx_matches_last_port() {
     let ports = ["Alpha", "Beta", "Gamma", "Delta"];
     assert_eq!(select_port_idx(&ports, Some("delta")), Some(3));
 }
+
+// -----------------------------------------------------------------------
+// BUG-016 acceptance: select_port_idx fallback edge cases.
+//
+// choose_midi_port (hw-io path) mirrors select_port_idx logic: when a
+// non-None filter matches no port it falls back to index 0 and emits
+// an eprintln warning. The following tests lock down every edge case of
+// the fallback branch in select_port_idx, which is the pure testable proxy.
+// -----------------------------------------------------------------------
+
+/// Empty-string filter is a substring of every port name: always matches
+/// index 0 (the first port), not the fallback path.
+#[test]
+fn select_port_idx_empty_filter_matches_first_port() {
+    let ports = ["Alpha", "Beta", "Gamma"];
+    // "" is contained in every string, so port 0 matches directly.
+    assert_eq!(select_port_idx(&ports, Some("")), Some(0));
+}
+
+/// When the filter matches ports at indices 1 and 2, the *first* match
+/// (index 1) is returned — not index 0 or 2.
+#[test]
+fn select_port_idx_filter_matches_multiple_returns_first_match() {
+    let ports = ["Alpha", "BetaMIDI", "GammaMIDI"];
+    // Both ports 1 and 2 contain "midi" — port 1 must win.
+    assert_eq!(select_port_idx(&ports, Some("midi")), Some(1));
+}
+
+/// Filter is all uppercase; port names are all lowercase. Case-insensitive
+/// match must still succeed.
+#[test]
+fn select_port_idx_uppercase_filter_matches_lowercase_port() {
+    let ports = ["fluidsynth", "timidity", "usb"];
+    assert_eq!(select_port_idx(&ports, Some("FLUID")), Some(0));
+    assert_eq!(select_port_idx(&ports, Some("TIMIDITY")), Some(1));
+}
+
+/// With five ports and a non-matching filter, fallback is still index 0
+/// regardless of list length.
+#[test]
+fn select_port_idx_fallback_with_many_ports_returns_zero() {
+    let ports = ["PortA", "PortB", "PortC", "PortD", "PortE"];
+    assert_eq!(select_port_idx(&ports, Some("ZZZ_nonexistent")), Some(0));
+}
+
+/// Filter matches exactly one port that is not index 0 in a longer list.
+#[test]
+fn select_port_idx_unique_match_not_at_zero() {
+    let ports = ["Alpha", "Beta", "SpecialSynth", "Delta", "Epsilon"];
+    assert_eq!(select_port_idx(&ports, Some("special")), Some(2));
+}


### PR DESCRIPTION
## Summary

- **BUG-015**: Removed dead `open_device()` function from `engine/src/hid.rs` (26 lines). After the BUG-008 fix, `run_hid` takes explicit `vid`/`pid` params and never called it; the hardcoded constants were misleading.
- **BUG-016**: Added `eprintln!` warning in `choose_midi_port` (`engine/src/midi_out.rs`) when a non-`None` port filter matches no port names before falling back to port 0 — users now see feedback instead of a silent wrong-port selection.
- **BUG-013**: Updated the developer comment in `.cargo/config.toml` to reference `cargo build --config .cargo/config.local.toml` instead of the non-existent `CARGO_CONFIG_TOML` env var.

## Key Architectural Decisions

- Warning uses `eprintln!` consistent with the project's existing fallback path in `select_port_idx`; no logger infrastructure required.
- `HID_VID` / `HID_PID` constants are retained — callers (`run_hid`) still use them as defaults; only the dead wrapper function was removed.

## Test Coverage

All tests are unit tests. 257 tests pass (`cargo test -p engine`):

- `engine/tests/cargo_config.rs` — 2 new tests asserting BUG-013 fix (env var removed, `--config` flag present)
- `engine/tests/hid.rs` — 1 new test asserting `HID_VID`/`HID_PID` constants remain exported after `open_device()` removal
- `engine/tests/midi_out.rs` — 5 new tests covering `select_port_idx` edge cases (empty filter, multi-match, case-insensitive, fallback, non-zero index match)
- `choose_midi_port` (hardware ALSA path) is not unit-tested by design; `select_port_idx` carries the testable logic

## Known Limitations / Follow-up

- Warning prefix `[midi]` in `choose_midi_port` differs slightly from `[midi_out]` used in `select_port_idx` — cosmetic inconsistency, no correctness impact (noted in code review)
- Pre-existing: `.workflow/BUGS.md` has a duplicate `BUG-015` entry (lines 427 and 519); the second should be renumbered BUG-017 in a separate cleanup commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)