### PR TITLE
fix: batch fix BUG-001–BUG-017 (17 known bugs)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,29 @@
 [build]
 # Default build targets the host. The firmware crate must be built explicitly
 # with `-p firmware` after setting its own .cargo/config.toml target.
+#
+# Local developer overrides (gitignored):
+# If your system is missing alsa-lib-devel, create .cargo/config.local.toml
+# with the following content and point Cargo at it via CARGO_CONFIG_TOML
+# or by temporarily editing this file (do not commit those changes):
+#
+#   # .cargo/config.local.toml  (gitignored)
+#   [env]
+#   PKG_CONFIG_PATH = "/tmp/alsa-pkg"
+#   [target.x86_64-unknown-linux-gnu]
+#   rustflags = ["-L", "/tmp/alsa-lib"]
+#
+# Create the helper files:
+#   mkdir -p /tmp/alsa-pkg && cat > /tmp/alsa-pkg/alsa.pc << 'EOF'
+#   prefix=/usr
+#   libdir=/usr/lib64
+#   includedir=/usr/include
+#   Name: alsa
+#   Version: 1.0
+#   Libs: -L/tmp/alsa-lib -lasound
+#   Cflags: -I/usr/include/alsa
+#   EOF
+#   mkdir -p /tmp/alsa-lib && ln -sf /usr/lib64/libasound.so.2 /tmp/alsa-lib/libasound.so
 
 [target.x86_64-unknown-linux-gnu]
 # No special linker needed for the engine on the host.

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,8 +4,9 @@
 #
 # Local developer overrides (gitignored):
 # If your system is missing alsa-lib-devel, create .cargo/config.local.toml
-# with the following content and point Cargo at it via CARGO_CONFIG_TOML
-# or by temporarily editing this file (do not commit those changes):
+# with the following content and activate it via:
+#   cargo build --config .cargo/config.local.toml
+# or temporarily edit this file (do not commit those changes):
 #
 #   # .cargo/config.local.toml  (gitignored)
 #   [env]

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ target/
 **/*.rs.bk
 Cargo.lock.bak
 
+# Local Cargo config overrides (host-specific workarounds — never commit)
+.cargo/config.local.toml
+
 # Agent worktrees (created and destroyed at runtime)
 .workflow/worktrees/*
 !.workflow/worktrees/.gitkeep

--- a/.workflow/plans/fix-hid-and-main.md
+++ b/.workflow/plans/fix-hid-and-main.md
@@ -1,0 +1,32 @@
+# Plan: fix-hid-and-main
+
+## Overview
+
+Fix four bugs in `engine/src/hid.rs`, `engine/src/midi_out.rs`, and `engine/src/main.rs`.
+All four were already resolved in prior commits on `fix/known-bugs`; this task
+verifies the fixes, confirms tests pass, and marks the work done.
+
+## Bug Summary
+
+| Bug | File | Fix |
+|-----|------|-----|
+| BUG-005 | `engine/tests/hid.rs` | Replace `unsafe transmute` with `offset_of!` assertions |
+| BUG-006 | `engine/src/hid.rs` | Zero `buf = [0u8; 64]` at top of each loop iteration |
+| BUG-008 | `engine/src/hid.rs`, `engine/src/midi_out.rs`, `engine/src/main.rs` | Add `vid`/`pid` params to `run_hid`; forward CLI args |
+| BUG-009 | `engine/src/main.rs` | Join all threads; skip clock in non-hw-io builds |
+
+## Steps
+
+1. Verify `engine/tests/hid.rs::in_report_field_offsets_match_wire_spec` uses `offset_of!` — confirmed (line 138).
+2. Verify `engine/src/hid.rs::run_hid` zeroes `buf` each iteration — confirmed (line 323).
+3. Verify `run_hid` accepts `vid: u16, pid: u16` params — confirmed (line 290-292).
+4. Verify `run_midi_out` accepts `port_name: Option<String>` — confirmed (line 268).
+5. Verify `main.rs` joins `cmd_thread`, `clock_thread`, `midi_thread` — confirmed (lines 182-188).
+6. Verify clock thread is only spawned under `#[cfg(feature = "hw-io")]` — confirmed (line 80).
+7. Run `cargo test -p engine` — 249 tests, 0 failures.
+
+## Test Command
+
+```
+cargo test -p engine
+```

--- a/.workflow/tasks/fix-hid-and-main.md
+++ b/.workflow/tasks/fix-hid-and-main.md
@@ -1,6 +1,6 @@
 # Task: fix-hid-and-main
 
-- **Status**: pending
+- **Status**: done
 - **Type**: coder
 - **Feature Branch**: fix/known-bugs
 - **Branch**: fix/known-bugs/fix-hid-and-main
@@ -81,3 +81,19 @@ For non-hw-io builds where the clock loop never naturally exits: add a shutdown 
 
 ## Notes
 
+All four bugs were already resolved in prior commits on `fix/known-bugs` before
+this task was dispatched. Verification confirmed each fix is in place:
+
+- **BUG-005**: `engine/tests/hid.rs` line 138 — `in_report_field_offsets_match_wire_spec`
+  uses `std::mem::offset_of!` for all 10 `InReport` fields; no `unsafe` present.
+- **BUG-006**: `engine/src/hid.rs` line 323 — `buf = [0u8; 64]` zeroed at the top of
+  each loop iteration before `device.read_timeout`.
+- **BUG-008**: `run_hid` accepts `vid: u16, pid: u16`; `run_midi_out` accepts
+  `port_name: Option<String>`; `main.rs` forwards `args.hid_vid`, `args.hid_pid`,
+  and `selected_midi_port` to the respective thread spawners.
+- **BUG-009**: Clock thread is only spawned under `#[cfg(feature = "hw-io")]`;
+  `main.rs` explicitly joins `cmd_thread`, `clock_thread`, and `midi_thread` in
+  dependency order after dropping all senders.
+
+Branch: `task/fix-hid-and-main` (worktree off `fix/known-bugs`)
+Test result: `cargo test -p engine` — 249 tests, 0 failures.

--- a/.workflow/tasks/fix-ratatui-crossterm-gate.md
+++ b/.workflow/tasks/fix-ratatui-crossterm-gate.md
@@ -1,6 +1,6 @@
 # Task: fix-ratatui-crossterm-gate
 
-- **Status**: pending
+- **Status**: done
 - **Type**: coder
 - **Feature Branch**: fix/known-bugs
 - **Branch**: fix/known-bugs/fix-ratatui-crossterm-gate
@@ -33,3 +33,16 @@ Ensure `crossterm` is only pulled in when the `hw-io` feature is enabled by decl
 
 ## Notes
 
+The fix was already present in `fix/known-bugs` as commit `55eba05`
+(`fix(terminal-ui): gate ratatui crossterm backend behind hw-io feature (BUG-007)`).
+
+**Branch:** `fix-ratatui-crossterm-gate` (worktree off `fix/known-bugs`)
+
+**What was verified:**
+- `engine/Cargo.toml` already has `ratatui` with `default-features = false, features = ["macros"]`
+- `crossterm` is declared as `optional = true`
+- `hw-io` feature gates both `crossterm` and `ratatui/crossterm`
+- `cargo tree -p engine` (without `--features hw-io`) shows no crossterm in the dependency tree
+- `cargo test -p engine` passes: 249 tests across 8 test suites (clock, hid, input, main_wiring, midi_out, music_theory, state, ui)
+
+No code changes were needed — BUG-007 was already fixed prior to this task being dispatched.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,8 @@ debug = 2
 opt-level = "s"
 lto = true
 codegen-units = 1
+
+# Strip debug symbols from firmware release builds to prevent flash-overflow
+# on RP2040 2 MB flash; engine retains debug = 2 for profiling.
+[profile.release.package.firmware]
+debug = false

--- a/engine/src/hid.rs
+++ b/engine/src/hid.rs
@@ -127,32 +127,6 @@ impl OutReport {
     }
 }
 
-/// Non-fatal HID device opener.
-///
-/// Returns `Some(device)` when the device is found and opened, or `None` when
-/// it is unavailable.  Errors are logged to stderr so the engine can continue
-/// with keyboard-only input.
-#[cfg(feature = "hw-io")]
-pub fn open_device() -> Option<hidapi::HidDevice> {
-    let api = match hidapi::HidApi::new() {
-        Ok(a) => a,
-        Err(e) => {
-            eprintln!("warn: hidapi init failed ({e}) — running without HID device");
-            return None;
-        }
-    };
-    match api.open(HID_VID, HID_PID) {
-        Ok(dev) => Some(dev),
-        Err(e) => {
-            eprintln!(
-                "warn: could not open HID device {:04X}:{:04X} ({e}) — running without HID device",
-                HID_VID, HID_PID
-            );
-            None
-        }
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Pure translation helpers — no hw-io dependency; fully unit-testable.
 // ---------------------------------------------------------------------------

--- a/engine/src/midi_out.rs
+++ b/engine/src/midi_out.rs
@@ -130,6 +130,9 @@ pub fn choose_midi_port(filter: Option<&str>) -> Option<String> {
     if let Some(f) = filter {
         let f_lower = f.to_lowercase();
         let matched = names.iter().find(|n| n.to_lowercase().contains(&f_lower));
+        if matched.is_none() {
+            eprintln!("[midi] port filter {:?} matched no ports; falling back to port 0", f);
+        }
         return Some(matched.unwrap_or(&names[0]).clone());
     }
 

--- a/engine/src/music_theory.rs
+++ b/engine/src/music_theory.rs
@@ -16,6 +16,34 @@ pub enum Key {
     B,
 }
 
+impl Key {
+    /// Number of Key variants.
+    pub const COUNT: usize = 12;
+
+    /// Convert a zero-based index (mod 12) to the corresponding Key variant.
+    pub fn from_index(i: usize) -> Self {
+        match i % Self::COUNT {
+            0 => Key::C,
+            1 => Key::Cs,
+            2 => Key::D,
+            3 => Key::Ds,
+            4 => Key::E,
+            5 => Key::F,
+            6 => Key::Fs,
+            7 => Key::G,
+            8 => Key::Gs,
+            9 => Key::A,
+            10 => Key::As,
+            _ => Key::B,
+        }
+    }
+
+    /// Return the zero-based index of this Key variant.
+    pub fn to_index(self) -> usize {
+        key_index(self)
+    }
+}
+
 /// Mode represents the available scales.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Mode {
@@ -28,6 +56,31 @@ pub enum Mode {
     Locrian,
     HarmonicMinor,
     MelodicMinor,
+}
+
+impl Mode {
+    /// Number of Mode variants.
+    pub const COUNT: usize = 9;
+
+    /// Convert a zero-based index (mod 9) to the corresponding Mode variant.
+    pub fn from_index(i: usize) -> Self {
+        match i % Self::COUNT {
+            0 => Mode::Major,
+            1 => Mode::NaturalMinor,
+            2 => Mode::Dorian,
+            3 => Mode::Phrygian,
+            4 => Mode::Lydian,
+            5 => Mode::Mixolydian,
+            6 => Mode::Locrian,
+            7 => Mode::HarmonicMinor,
+            _ => Mode::MelodicMinor,
+        }
+    }
+
+    /// Return the zero-based index of this Mode variant.
+    pub fn to_index(self) -> usize {
+        mode_index(self)
+    }
 }
 
 /// Semitone intervals between successive scale degrees for each mode.

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -27,6 +27,35 @@ pub enum StepSize {
     ThirtySecond,
 }
 
+impl StepSize {
+    /// Number of StepSize variants.
+    pub const COUNT: usize = 6;
+
+    /// Convert a zero-based index (mod 6) to the corresponding StepSize variant.
+    pub fn from_index(i: usize) -> Self {
+        match i % Self::COUNT {
+            0 => StepSize::Whole,
+            1 => StepSize::Half,
+            2 => StepSize::Quarter,
+            3 => StepSize::Eighth,
+            4 => StepSize::Sixteenth,
+            _ => StepSize::ThirtySecond,
+        }
+    }
+
+    /// Return the zero-based index of this StepSize variant.
+    pub fn to_index(self) -> usize {
+        match self {
+            StepSize::Whole => 0,
+            StepSize::Half => 1,
+            StepSize::Quarter => 2,
+            StepSize::Eighth => 3,
+            StepSize::Sixteenth => 4,
+            StepSize::ThirtySecond => 5,
+        }
+    }
+}
+
 /// Pending parameter edit awaiting confirmation.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum PendingEdit {
@@ -225,8 +254,12 @@ impl SequencerState {
             }
             InputCommand::NoteDelta(d) => {
                 let step = self.selected_step;
-                let current_note = self.steps[step].midi_note;
-                let new_note = crate::music_theory::next_note(current_note, self.key, self.mode, d);
+                // Seed from pending note so repeated presses accumulate correctly.
+                let base_note = match self.pending_edit {
+                    PendingEdit::Note { step: ps, midi_note } if ps == step => midi_note,
+                    _ => self.steps[step].midi_note,
+                };
+                let new_note = crate::music_theory::next_note(base_note, self.key, self.mode, d);
                 self.pending_edit = PendingEdit::Note { step, midi_note: new_note };
             }
             InputCommand::Confirm => {
@@ -244,9 +277,9 @@ impl SequencerState {
                         }
                         self.pending_edit = PendingEdit::None;
                     }
-                    PendingEdit::Param { .. } => {
-                        // Param commits are handled by Step 7 (param overlay logic).
-                        // Clear the pending edit after confirmation.
+                    PendingEdit::Param { index, value, .. } => {
+                        // Apply the pending param value to the matching state field.
+                        self.apply_param_value(index, value);
                         self.pending_edit = PendingEdit::None;
                     }
                 }
@@ -274,12 +307,12 @@ impl SequencerState {
                 }
             }
             InputCommand::ParamSelect(n) => {
-                self.selected_param = n.min(6);
+                self.selected_param = n.min(7);
             }
             InputCommand::ParamSelectDelta(d) => {
-                // 7 params (indices 0–6), wrap modulo 7.
+                // 8 params (indices 0–7), wrap modulo 8.
                 let current = self.selected_param as i32;
-                let next = ((current + d as i32).rem_euclid(7)) as u8;
+                let next = ((current + d as i32).rem_euclid(8)) as u8;
                 self.selected_param = next;
             }
             InputCommand::ParamValueDelta(d) => {
@@ -288,15 +321,14 @@ impl SequencerState {
                     None => return, // No overlay open — ignore.
                 };
                 let index = self.selected_param;
+                // Seed from the current committed state value so the pending value
+                // is always in the same unit space as the state field.
                 let current_value = match self.pending_edit {
                     PendingEdit::Param { index: pi, value, .. } if pi == index => value,
-                    _ => 0,
+                    _ => self.committed_param_value(index),
                 };
-                self.pending_edit = PendingEdit::Param {
-                    overlay,
-                    index,
-                    value: current_value + d as i64,
-                };
+                let new_value = self.clamped_param_value(index, current_value + d as i64);
+                self.pending_edit = PendingEdit::Param { overlay, index, value: new_value };
             }
             InputCommand::PlayStop => {
                 if self.playing {
@@ -307,6 +339,135 @@ impl SequencerState {
                 }
             }
         }
+    }
+
+    /// Return the current committed state value for param `index` as an i64
+    /// in the same unit space used by `PendingEdit::Param`.
+    ///
+    /// Enum params use the variant index; numeric params use the raw value.
+    /// Regular overlay indices: 0=Key, 1=Mode, 2=Swing, 3=StepSize,
+    /// 4=loop_in, 5=loop_out, 6=paused, 7=playing.
+    fn committed_param_value(&self, index: u8) -> i64 {
+        match index {
+            0 => self.key.to_index() as i64,
+            1 => self.mode.to_index() as i64,
+            2 => self.swing as i64,
+            3 => self.step_size.to_index() as i64,
+            4 => self.loop_in as i64,
+            5 => self.loop_out as i64,
+            6 => self.paused as i64,
+            7 => self.playing as i64,
+            _ => 0,
+        }
+    }
+
+    /// Clamp or wrap the raw `value` into the valid range for param `index`.
+    fn clamped_param_value(&self, index: u8, value: i64) -> i64 {
+        match index {
+            0 => value.rem_euclid(Key::COUNT as i64),
+            1 => value.rem_euclid(Mode::COUNT as i64),
+            2 => value.clamp(-50, 50),
+            3 => value.rem_euclid(StepSize::COUNT as i64),
+            4 | 5 => value.clamp(0, 15),
+            6 | 7 => value.clamp(0, 1),
+            _ => value,
+        }
+    }
+
+    /// Write the resolved `value` for param `index` back to the matching state field.
+    ///
+    /// Regular overlay indices: 0=Key, 1=Mode, 2=Swing, 3=StepSize,
+    /// 4=loop_in, 5=loop_out, 6=paused, 7=playing.
+    /// BUG-017: setting playing=true (index 7, value 1) also clears paused.
+    fn apply_param_value(&mut self, index: u8, value: i64) {
+        match index {
+            0 => self.key = Key::from_index(value as usize),
+            1 => self.mode = Mode::from_index(value as usize),
+            2 => self.swing = value as i8,
+            3 => self.step_size = StepSize::from_index(value as usize),
+            4 => self.loop_in = value as u8,
+            5 => self.loop_out = value as u8,
+            6 => self.paused = value != 0,
+            7 => {
+                self.playing = value != 0;
+                if self.playing {
+                    self.paused = false;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::input::OverlayMode;
+
+    // ── BUG-014: loop_out edit path ──────────────────────────────────────────
+
+    #[test]
+    fn test_loop_out_edit_path_via_overlay() {
+        let mut state = SequencerState::default();
+        // Simulate a pending param edit for loop_out (index 5) with value 10.
+        state.pending_edit = PendingEdit::Param {
+            overlay: OverlayMode::Regular,
+            index: 5,
+            value: 10,
+        };
+        // Confirm should apply loop_out = 10.
+        state.apply_command(InputCommand::Confirm);
+        assert_eq!(state.loop_out, 10);
+        assert_eq!(state.pending_edit, PendingEdit::None);
+    }
+
+    #[test]
+    fn test_committed_param_value_loop_out() {
+        let mut state = SequencerState::default();
+        state.loop_out = 12;
+        assert_eq!(state.committed_param_value(5), 12);
+    }
+
+    #[test]
+    fn test_param_select_delta_wraps_at_8() {
+        let mut state = SequencerState::default();
+        state.selected_param = 7;
+        state.apply_command(InputCommand::ParamSelectDelta(1));
+        assert_eq!(state.selected_param, 0);
+    }
+
+    // ── BUG-017: overlay confirm playing=true clears paused ─────────────────
+
+    #[test]
+    fn test_confirm_playing_clears_paused() {
+        let mut state = SequencerState::default();
+        state.paused = true;
+        state.playing = false;
+        // Simulate a pending param edit: index 7 (playing), value 1.
+        state.pending_edit = PendingEdit::Param {
+            overlay: OverlayMode::Regular,
+            index: 7,
+            value: 1,
+        };
+        state.apply_command(InputCommand::Confirm);
+        assert!(state.playing, "playing should be true after confirm");
+        assert!(!state.paused, "paused should be cleared when playing is set via overlay");
+    }
+
+    #[test]
+    fn test_confirm_playing_false_does_not_clear_paused() {
+        let mut state = SequencerState::default();
+        state.paused = true;
+        state.playing = true;
+        // Set playing=false via overlay — paused should be left unchanged.
+        state.pending_edit = PendingEdit::Param {
+            overlay: OverlayMode::Regular,
+            index: 7,
+            value: 0,
+        };
+        state.apply_command(InputCommand::Confirm);
+        assert!(!state.playing);
+        assert!(state.paused, "paused should be unchanged when playing is set to false");
     }
 }
 

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -254,7 +254,7 @@ impl SequencerState {
             }
             InputCommand::NoteDelta(d) => {
                 let step = self.selected_step;
-                // Seed from pending note so repeated presses accumulate correctly.
+                // BUG-010 fix: use pending note as base so repeated presses accumulate.
                 let base_note = match self.pending_edit {
                     PendingEdit::Note { step: ps, midi_note } if ps == step => midi_note,
                     _ => self.steps[step].midi_note,
@@ -278,7 +278,7 @@ impl SequencerState {
                         self.pending_edit = PendingEdit::None;
                     }
                     PendingEdit::Param { index, value, .. } => {
-                        // Apply the pending param value to the matching state field.
+                        // BUG-012 fix: apply the pending param value to the state field.
                         self.apply_param_value(index, value);
                         self.pending_edit = PendingEdit::None;
                     }
@@ -321,8 +321,8 @@ impl SequencerState {
                     None => return, // No overlay open — ignore.
                 };
                 let index = self.selected_param;
-                // Seed from the current committed state value so the pending value
-                // is always in the same unit space as the state field.
+                // BUG-011 fix: seed from the current committed state value so the
+                // pending value is always in the same unit space as the state field.
                 let current_value = match self.pending_edit {
                     PendingEdit::Param { index: pi, value, .. } if pi == index => value,
                     _ => self.committed_param_value(index),

--- a/engine/src/ui_render.rs
+++ b/engine/src/ui_render.rs
@@ -20,13 +20,14 @@ use crate::music_theory::note_name;
 use crate::state::{PendingEdit, SequencerState, StepSize};
 use crate::music_theory::{Key, Mode};
 
-/// Regular overlay parameter names (index 0–6).
-pub const REGULAR_PARAMS: [&str; 7] = [
+/// Regular overlay parameter names (index 0–7).
+pub const REGULAR_PARAMS: [&str; 8] = [
     "Key",
     "Mode",
     "Swing",
     "Step Size",
-    "Loop",
+    "Loop In",
+    "Loop Out",
     "Pause",
     "Stop/Start",
 ];
@@ -254,7 +255,7 @@ fn render_overlay(
                 _ => None,
             };
 
-            let mut spans: Vec<Span> = Vec::with_capacity(7 * 3);
+            let mut spans: Vec<Span> = Vec::with_capacity(8 * 3);
             for (i, name) in REGULAR_PARAMS.iter().enumerate() {
                 let idx = i as u8;
                 let is_highlighted = idx == selected_param;
@@ -277,7 +278,7 @@ fn render_overlay(
                     Style::default()
                 };
                 spans.push(Span::styled(display, style));
-                if i < 6 {
+                if i < REGULAR_PARAMS.len() - 1 {
                     spans.push(Span::raw("|"));
                 }
             }
@@ -291,23 +292,21 @@ fn render_overlay(
 }
 
 /// Return a short string representation of parameter `index` current value.
+///
+/// Index map: 0=Key, 1=Mode, 2=Swing, 3=StepSize, 4=loop_in, 5=loop_out,
+/// 6=paused, 7=playing.
 fn param_value_string(state: &SequencerState, index: u8) -> String {
     match index {
         0 => key_name(state.key).to_string(),
         1 => mode_name(state.mode).to_string(),
         2 => format!("{:+}", state.swing),
         3 => step_size_label(state.step_size).to_string(),
-        4 => {
-            if state.loop_active {
-                format!("{}–{}", state.loop_in, state.loop_out)
-            } else {
-                "off".to_string()
-            }
-        }
-        5 => {
+        4 => state.loop_in.to_string(),
+        5 => state.loop_out.to_string(),
+        6 => {
             if state.paused { "on" } else { "off" }.to_string()
         }
-        6 => {
+        7 => {
             if state.playing { "playing" } else { "stopped" }.to_string()
         }
         _ => "?".to_string(),

--- a/engine/src/ui_render.rs
+++ b/engine/src/ui_render.rs
@@ -264,7 +264,10 @@ fn render_overlay(
                 let value_str = param_value_string(state, idx);
                 let display = if let Some((pi, pv)) = pending_param_value {
                     if pi == idx {
-                        format!(" {}[{}→{}] ", name, value_str, pv)
+                        // BUG-011 fix: format pending value with the same human-readable
+                        // formatter used for the committed value, not as a raw number.
+                        let pending_str = pending_param_value_string(idx, pv);
+                        format!(" {}[{}→{}] ", name, value_str, pending_str)
                     } else {
                         format!(" {}:{} ", name, value_str)
                     }
@@ -309,6 +312,24 @@ fn param_value_string(state: &SequencerState, index: u8) -> String {
         7 => {
             if state.playing { "playing" } else { "stopped" }.to_string()
         }
+        _ => "?".to_string(),
+    }
+}
+
+/// Return a human-readable string for a pending parameter value `v` at `index`.
+///
+/// `v` is the fully-resolved value stored in `PendingEdit::Param`, in the same
+/// unit space as the committed field.  Enum params are converted back to their
+/// named variant; numeric params are formatted as numbers.
+fn pending_param_value_string(index: u8, v: i64) -> String {
+    match index {
+        0 => key_name(Key::from_index(v as usize)).to_string(),
+        1 => mode_name(Mode::from_index(v as usize)).to_string(),
+        2 => format!("{:+}", v as i8),
+        3 => step_size_label(StepSize::from_index(v as usize)).to_string(),
+        4 | 5 => format!("{}", v),
+        6 => if v != 0 { "on".to_string() } else { "off".to_string() },
+        7 => if v != 0 { "playing".to_string() } else { "stopped".to_string() },
         _ => "?".to_string(),
     }
 }

--- a/engine/tests/cargo_config.rs
+++ b/engine/tests/cargo_config.rs
@@ -1,0 +1,105 @@
+/// Tests for BUG-003: hardcoded /tmp ALSA paths must not appear as live config
+/// values in `.cargo/config.toml`, and `.gitignore` must contain the entry for
+/// the gitignored local-override file.
+///
+/// `CARGO_MANIFEST_DIR` is set by Cargo to the engine crate root at test time.
+/// The workspace root (where `.cargo/config.toml` and `.gitignore` live) is one
+/// directory above.
+
+use std::path::PathBuf;
+
+/// Return the workspace root directory (one level above the engine crate root).
+fn workspace_root() -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest_dir).parent().expect("engine crate must have a parent directory").to_path_buf()
+}
+
+/// Read `.cargo/config.toml` from the workspace root and return all non-comment,
+/// non-blank lines. A line is a comment line if its first non-whitespace
+/// character is `#`.
+fn live_config_lines() -> Vec<String> {
+    let path = workspace_root().join(".cargo/config.toml");
+    let content = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e));
+    content
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty() && !trimmed.starts_with('#')
+        })
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Read the full text of `.cargo/config.toml` (including comment lines).
+fn full_cargo_config() -> String {
+    let path = workspace_root().join(".cargo/config.toml");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
+}
+
+/// Read the full text of `.gitignore`.
+fn gitignore_contents() -> String {
+    let path = workspace_root().join(".gitignore");
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
+}
+
+// ---------------------------------------------------------------------------
+// T1 – no live (non-comment) line in .cargo/config.toml contains /tmp/alsa-pkg
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cargo_config_no_live_tmp_alsa_pkg() {
+    let live_lines = live_config_lines();
+    for line in &live_lines {
+        assert!(
+            !line.contains("/tmp/alsa-pkg"),
+            "live config line must not reference /tmp/alsa-pkg (BUG-003): found '{line}'"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// T2 – no live (non-comment) line in .cargo/config.toml contains /tmp/alsa-lib
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cargo_config_no_live_tmp_alsa_lib() {
+    let live_lines = live_config_lines();
+    for line in &live_lines {
+        assert!(
+            !line.contains("/tmp/alsa-lib"),
+            "live config line must not reference /tmp/alsa-lib (BUG-003): found '{line}'"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// T3 – .gitignore contains .cargo/config.local.toml
+// ---------------------------------------------------------------------------
+
+#[test]
+fn gitignore_contains_config_local_toml() {
+    let contents = gitignore_contents();
+    let has_entry = contents
+        .lines()
+        .any(|line| line.trim() == ".cargo/config.local.toml");
+    assert!(
+        has_entry,
+        ".gitignore must contain a '.cargo/config.local.toml' entry so local overrides are never committed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// T4 – .cargo/config.toml documents the local-override pattern in a comment
+// ---------------------------------------------------------------------------
+
+#[test]
+fn cargo_config_documents_local_override_pattern() {
+    let contents = full_cargo_config();
+    assert!(
+        contents.contains(".cargo/config.local.toml"),
+        ".cargo/config.toml must mention '.cargo/config.local.toml' in a comment to document the local-override pattern for developers"
+    );
+}

--- a/engine/tests/cargo_config.rs
+++ b/engine/tests/cargo_config.rs
@@ -2,11 +2,14 @@
 /// values in `.cargo/config.toml`, and `.gitignore` must contain the entry for
 /// the gitignored local-override file.
 ///
+/// BUG-013 acceptance tests: .cargo/config.toml comment must reference the
+/// correct `--config` invocation, not the non-existent CARGO_CONFIG_TOML env var.
+///
 /// `CARGO_MANIFEST_DIR` is set by Cargo to the engine crate root at test time.
 /// The workspace root (where `.cargo/config.toml` and `.gitignore` live) is one
 /// directory above.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Return the workspace root directory (one level above the engine crate root).
 fn workspace_root() -> PathBuf {
@@ -36,6 +39,13 @@ fn full_cargo_config() -> String {
     let path = workspace_root().join(".cargo/config.toml");
     std::fs::read_to_string(&path)
         .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
+}
+
+fn read_cargo_config() -> String {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let config_path = Path::new(manifest_dir).join("..").join(".cargo").join("config.toml");
+    std::fs::read_to_string(&config_path)
+        .unwrap_or_else(|e| panic!("cannot read .cargo/config.toml at {}: {e}", config_path.display()))
 }
 
 /// Read the full text of `.gitignore`.
@@ -101,5 +111,32 @@ fn cargo_config_documents_local_override_pattern() {
     assert!(
         contents.contains(".cargo/config.local.toml"),
         ".cargo/config.toml must mention '.cargo/config.local.toml' in a comment to document the local-override pattern for developers"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// BUG-013 – .cargo/config.toml must not reference CARGO_CONFIG_TOML env var
+// ---------------------------------------------------------------------------
+
+/// The non-existent `CARGO_CONFIG_TOML` environment variable must not appear
+/// in .cargo/config.toml. Before BUG-013 was fixed the developer comment
+/// incorrectly told users to set this env var.
+#[test]
+fn cargo_config_toml_does_not_reference_cargo_config_toml_env_var() {
+    let content = read_cargo_config();
+    assert!(
+        !content.contains("CARGO_CONFIG_TOML"),
+        ".cargo/config.toml must not reference the non-existent CARGO_CONFIG_TOML env var (BUG-013)"
+    );
+}
+
+/// After BUG-013 was fixed, the comment must document the correct invocation:
+/// `--config .cargo/config.local.toml`.
+#[test]
+fn cargo_config_toml_references_config_local_toml_flag() {
+    let content = read_cargo_config();
+    assert!(
+        content.contains("--config .cargo/config.local.toml"),
+        ".cargo/config.toml must contain '--config .cargo/config.local.toml' (BUG-013)"
     );
 }

--- a/engine/tests/cargo_profile.rs
+++ b/engine/tests/cargo_profile.rs
@@ -1,0 +1,174 @@
+/// Tests that validate the workspace Cargo.toml profile configuration
+/// introduced in the fix-cargo-firmware-debug task.
+///
+/// These tests read the workspace Cargo.toml at test time and verify:
+///   - `[profile.release.package.firmware]` with `debug = false` is present.
+///   - No `[profile.release.package.engine]` override exists (engine retains
+///     workspace-level `debug = 2`).
+///   - The workspace `[profile.release]` section retains `debug = 2`.
+///
+/// Tests use line-based string search rather than a TOML parser to avoid a
+/// dev-dependency, and use CARGO_MANIFEST_DIR to locate the workspace root
+/// reliably regardless of the working directory at test invocation time.
+
+use std::path::PathBuf;
+
+/// Returns the workspace root by traversing up from CARGO_MANIFEST_DIR
+/// (which points at engine/) until we find the file that contains
+/// `[workspace]`.
+fn workspace_cargo_toml() -> PathBuf {
+    // CARGO_MANIFEST_DIR is set by cargo test to the crate being tested.
+    // For this crate that is <workspace>/engine.
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .expect("CARGO_MANIFEST_DIR must be set by cargo");
+    let mut path = PathBuf::from(manifest_dir);
+
+    // Walk up until we find a Cargo.toml that contains `[workspace]`.
+    loop {
+        let candidate = path.join("Cargo.toml");
+        if candidate.exists() {
+            let content = std::fs::read_to_string(&candidate)
+                .unwrap_or_default();
+            if content.contains("[workspace]") {
+                return candidate;
+            }
+        }
+        match path.parent() {
+            Some(parent) => path = parent.to_path_buf(),
+            None => panic!("could not locate workspace Cargo.toml"),
+        }
+    }
+}
+
+/// Helper: read the workspace Cargo.toml content as a String.
+fn read_workspace_cargo_toml() -> String {
+    let path = workspace_cargo_toml();
+    std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", path.display(), e))
+}
+
+// ---------------------------------------------------------------------------
+// 1. File existence
+// ---------------------------------------------------------------------------
+
+#[test]
+fn workspace_cargo_toml_exists() {
+    let path = workspace_cargo_toml();
+    assert!(
+        path.exists(),
+        "workspace Cargo.toml not found at expected location: {}",
+        path.display()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. firmware release profile override is present
+// ---------------------------------------------------------------------------
+
+#[test]
+fn firmware_release_profile_section_present() {
+    let content = read_workspace_cargo_toml();
+    assert!(
+        content.contains("[profile.release.package.firmware]"),
+        "workspace Cargo.toml must contain [profile.release.package.firmware] table"
+    );
+}
+
+#[test]
+fn firmware_release_profile_has_debug_false() {
+    let content = read_workspace_cargo_toml();
+
+    // Find the firmware override section and verify `debug = false` follows it
+    // before the next section header begins.
+    let section_start = content
+        .find("[profile.release.package.firmware]")
+        .expect("section [profile.release.package.firmware] not found in workspace Cargo.toml");
+
+    let after_section = &content[section_start..];
+
+    // The `debug = false` must appear before the next `[` heading (or end of file).
+    let end_of_section = after_section[1..] // skip the opening `[` of this section
+        .find('[')
+        .map(|idx| idx + 1)   // offset back relative to after_section
+        .unwrap_or(after_section.len());
+
+    let section_body = &after_section[..end_of_section];
+
+    assert!(
+        section_body.contains("debug = false"),
+        "expected `debug = false` inside [profile.release.package.firmware], \
+         but section body was:\n{}",
+        section_body
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Engine has no per-package release profile override
+// ---------------------------------------------------------------------------
+
+#[test]
+fn engine_has_no_release_package_override() {
+    let content = read_workspace_cargo_toml();
+    assert!(
+        !content.contains("[profile.release.package.engine]"),
+        "workspace Cargo.toml must NOT contain [profile.release.package.engine] — \
+         engine must inherit debug = 2 from the workspace release profile"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Workspace release profile retains debug = 2
+// ---------------------------------------------------------------------------
+
+#[test]
+fn workspace_release_profile_debug_is_2() {
+    let content = read_workspace_cargo_toml();
+
+    // Find the workspace-level [profile.release] section (not the firmware sub-section).
+    // We look for a line that is exactly `[profile.release]` (no `.package.`).
+    let section_start = content
+        .find("[profile.release]\n")
+        .expect("workspace [profile.release] section not found");
+
+    let after_section = &content[section_start..];
+
+    // Grab content up to the next `[` heading (the firmware override or EOF).
+    let end_of_section = after_section[1..]
+        .find('[')
+        .map(|idx| idx + 1)
+        .unwrap_or(after_section.len());
+
+    let section_body = &after_section[..end_of_section];
+
+    assert!(
+        section_body.contains("debug = 2"),
+        "workspace [profile.release] must retain `debug = 2` for engine profiling; \
+         section body was:\n{}",
+        section_body
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. firmware debug override does not bleed into engine profile
+// ---------------------------------------------------------------------------
+
+#[test]
+fn firmware_override_does_not_affect_engine_profile() {
+    // Confirm that there is exactly one per-package firmware override and zero
+    // per-package engine overrides.  This is a combined check of tests 3 & 2.
+    let content = read_workspace_cargo_toml();
+
+    let firmware_overrides = content.matches("[profile.release.package.firmware]").count();
+    assert_eq!(
+        firmware_overrides, 1,
+        "expected exactly one [profile.release.package.firmware] section, found {}",
+        firmware_overrides
+    );
+
+    let engine_overrides = content.matches("[profile.release.package.engine]").count();
+    assert_eq!(
+        engine_overrides, 0,
+        "expected zero [profile.release.package.engine] sections, found {}",
+        engine_overrides
+    );
+}

--- a/engine/tests/clock.rs
+++ b/engine/tests/clock.rs
@@ -313,6 +313,129 @@ fn tick_no_events_sent_when_paused() {
     assert!(rx.try_recv().is_err(), "no events should be sent when paused=true");
 }
 
+// --- add_nanos_signed: epoch clamp and edge cases ---
+
+#[test]
+fn add_nanos_signed_actual_epoch_clamp_sub_second() {
+    // tv_sec=0, tv_nsec=50_000_000 (50 ms), subtract 100 ms → goes below epoch → clamped to 0.
+    let ts = libc::timespec { tv_sec: 0, tv_nsec: 50_000_000 };
+    let result = add_nanos_signed(ts, -100_000_000);
+    assert_eq!(result.tv_sec, 0, "tv_sec must be 0 when clamped to epoch");
+    assert_eq!(result.tv_nsec, 0, "tv_nsec must be 0 when clamped to epoch");
+}
+
+#[test]
+fn add_nanos_signed_clamp_at_exact_epoch() {
+    // Offset that brings the result to exactly zero (no positive remainder).
+    let ts = libc::timespec { tv_sec: 1, tv_nsec: 0 };
+    let result = add_nanos_signed(ts, -1_000_000_000);
+    assert_eq!(result.tv_sec, 0, "tv_sec must be 0 when result is exactly the epoch");
+    assert_eq!(result.tv_nsec, 0, "tv_nsec must be 0 when result is exactly the epoch");
+}
+
+#[test]
+fn add_nanos_signed_zero_offset_leaves_timespec_unchanged() {
+    let ts = libc::timespec { tv_sec: 3, tv_nsec: 456_789_000 };
+    let result = add_nanos_signed(ts, 0);
+    assert_eq!(result.tv_sec, 3, "tv_sec must be unchanged for zero offset");
+    assert_eq!(result.tv_nsec, 456_789_000, "tv_nsec must be unchanged for zero offset");
+}
+
+#[test]
+fn add_nanos_signed_large_positive_spans_multiple_seconds() {
+    // 1.0s + 2_500_000_000 ns = 3.5s → tv_sec=3, tv_nsec=500_000_000
+    let ts = libc::timespec { tv_sec: 1, tv_nsec: 0 };
+    let result = add_nanos_signed(ts, 2_500_000_000);
+    assert_eq!(result.tv_sec, 3, "tv_sec should be 3 after spanning 2 full seconds");
+    assert_eq!(result.tv_nsec, 500_000_000, "tv_nsec should be 500_000_000 ns");
+}
+
+#[test]
+fn add_nanos_signed_large_negative_spans_multiple_seconds() {
+    // 10.0s - 3_200_000_000 ns = 6.8s → tv_sec=6, tv_nsec=800_000_000
+    let ts = libc::timespec { tv_sec: 10, tv_nsec: 0 };
+    let result = add_nanos_signed(ts, -3_200_000_000);
+    assert_eq!(result.tv_sec, 6, "tv_sec should be 6 after subtracting 3.2 seconds");
+    assert_eq!(result.tv_nsec, 800_000_000, "tv_nsec should be 800_000_000 ns");
+}
+
+#[test]
+fn add_nanos_signed_at_large_time_with_boundary_crossing_negative() {
+    // Simulates a running monotonic clock at ~100s with 120 BPM swing subtraction.
+    // 100.010s - 62.5ms = 99.9475s → tv_sec=99, tv_nsec=947_500_000
+    let ts = libc::timespec { tv_sec: 100, tv_nsec: 10_000_000 };
+    let result = add_nanos_signed(ts, -62_500_000);
+    assert_eq!(result.tv_sec, 99);
+    assert_eq!(result.tv_nsec, 947_500_000);
+}
+
+// --- add_nanos: edge cases ---
+
+#[test]
+fn add_nanos_zero_nanos_leaves_timespec_unchanged() {
+    let ts = libc::timespec { tv_sec: 7, tv_nsec: 123_456_789 };
+    let result = add_nanos(ts, 0);
+    assert_eq!(result.tv_sec, 7, "tv_sec must be unchanged when adding zero nanoseconds");
+    assert_eq!(result.tv_nsec, 123_456_789, "tv_nsec must be unchanged when adding zero nanoseconds");
+}
+
+#[test]
+fn add_nanos_exactly_one_second() {
+    // Adding exactly 1_000_000_000 ns to tv_nsec=0 must increment tv_sec by 1.
+    let ts = libc::timespec { tv_sec: 5, tv_nsec: 0 };
+    let result = add_nanos(ts, 1_000_000_000);
+    assert_eq!(result.tv_sec, 6, "tv_sec must increment by 1 when adding exactly one second");
+    assert_eq!(result.tv_nsec, 0, "tv_nsec must be 0 when adding exactly one second to a zero nsec");
+}
+
+#[test]
+fn add_nanos_spans_multiple_seconds() {
+    // 0.5s + 2_500_000_000 ns = 3.0s → tv_sec=3, tv_nsec=0
+    let ts = libc::timespec { tv_sec: 0, tv_nsec: 500_000_000 };
+    let result = add_nanos(ts, 2_500_000_000);
+    assert_eq!(result.tv_sec, 3, "tv_sec should be 3 after spanning 2.5 seconds");
+    assert_eq!(result.tv_nsec, 0, "tv_nsec should be 0");
+}
+
+// --- swing integration: add_nanos_signed with realistic swing offsets ---
+
+#[test]
+fn swing_120bpm_negative50_does_not_underflow_sub_second_start() {
+    // If the base time is less than the max negative swing offset, clamping must
+    // prevent tv_nsec < 0 and tv_sec < 0.
+    let period = tick_nanos(120, StepSize::Sixteenth); // 125_000_000 ns
+    let offset = swing_offset_nanos(-50, period);      // -62_500_000 ns
+    // Start at 30 ms — less than the 62.5 ms offset — so the result goes below 0.
+    let ts = libc::timespec { tv_sec: 0, tv_nsec: 30_000_000 };
+    let result = add_nanos_signed(ts, offset);
+    assert!(result.tv_sec >= 0, "tv_sec must not be negative after epoch clamp");
+    assert!(result.tv_nsec >= 0, "tv_nsec must not be negative after epoch clamp");
+    assert_eq!(result.tv_sec, 0, "should be clamped to epoch");
+    assert_eq!(result.tv_nsec, 0, "should be clamped to epoch");
+}
+
+#[test]
+fn swing_120bpm_positive50_odd_step_delay_is_correct() {
+    // Odd step at 5.000s with +50 swing: wake time should be 5.000s + 62.5ms = 5.0625s
+    let period = tick_nanos(120, StepSize::Sixteenth); // 125_000_000 ns
+    let offset = swing_offset_nanos(50, period);       // +62_500_000 ns
+    let ts = libc::timespec { tv_sec: 5, tv_nsec: 0 };
+    let result = add_nanos_signed(ts, offset);
+    assert_eq!(result.tv_sec, 5, "tv_sec should remain 5 for a sub-second positive offset");
+    assert_eq!(result.tv_nsec, 62_500_000, "tv_nsec should be 62_500_000 ns");
+}
+
+#[test]
+fn swing_120bpm_negative50_odd_step_advance_is_correct() {
+    // Odd step at 5.100s with -50 swing: wake time should be 5.100s - 62.5ms = 5.0375s
+    let period = tick_nanos(120, StepSize::Sixteenth); // 125_000_000 ns
+    let offset = swing_offset_nanos(-50, period);      // -62_500_000 ns
+    let ts = libc::timespec { tv_sec: 5, tv_nsec: 100_000_000 };
+    let result = add_nanos_signed(ts, offset);
+    assert_eq!(result.tv_sec, 5, "tv_sec should remain 5");
+    assert_eq!(result.tv_nsec, 37_500_000, "tv_nsec should be 37_500_000 ns");
+}
+
 // --- NoteOn carries duration_nanos from tick_nanos ---
 
 #[test]

--- a/engine/tests/hid.rs
+++ b/engine/tests/hid.rs
@@ -637,3 +637,21 @@ fn translate_encoder_delta_with_active_overlay_emits_note_delta_not_param_value_
     assert!(matches!(cmds[1], InputCommand::NoteDelta(2)),
         "cmds[1] should be NoteDelta(2) — overlay-aware routing is deferred; got {:?}", cmds[1]);
 }
+
+// -----------------------------------------------------------------------
+// BUG-015: open_device() is gone — only constants remain.
+// -----------------------------------------------------------------------
+
+/// `HID_VID` and `HID_PID` constants are still exported after `open_device()` was
+/// removed (BUG-015). Callers use these constants as default arguments to `run_hid`.
+///
+/// Note: attempting to import `engine::hid::open_device` on this branch would
+/// produce a compile error (`use of undeclared crate or module item`), which is the
+/// intended proof that dead code was removed.  A `compile_fail` doc-test would be
+/// the canonical form; we document the intent here instead.
+#[test]
+fn hid_vid_pid_constants_still_exported_after_open_device_removal() {
+    // HID_VID and HID_PID must remain accessible — they are used by run_hid callers.
+    assert_eq!(HID_VID, 0x2E8A, "HID_VID must still be 0x2E8A after open_device removal");
+    assert_eq!(HID_PID, 0x000A, "HID_PID must still be 0x000A after open_device removal");
+}

--- a/engine/tests/midi_out.rs
+++ b/engine/tests/midi_out.rs
@@ -319,3 +319,54 @@ fn select_port_idx_matches_last_port() {
     let ports = ["Alpha", "Beta", "Gamma", "Delta"];
     assert_eq!(select_port_idx(&ports, Some("delta")), Some(3));
 }
+
+// -----------------------------------------------------------------------
+// BUG-016 acceptance: select_port_idx fallback edge cases.
+//
+// choose_midi_port (hw-io path) mirrors select_port_idx logic: when a
+// non-None filter matches no port it falls back to index 0 and emits
+// an eprintln warning. The following tests lock down every edge case of
+// the fallback branch in select_port_idx, which is the pure testable proxy.
+// -----------------------------------------------------------------------
+
+/// Empty-string filter is a substring of every port name: always matches
+/// index 0 (the first port), not the fallback path.
+#[test]
+fn select_port_idx_empty_filter_matches_first_port() {
+    let ports = ["Alpha", "Beta", "Gamma"];
+    // "" is contained in every string, so port 0 matches directly.
+    assert_eq!(select_port_idx(&ports, Some("")), Some(0));
+}
+
+/// When the filter matches ports at indices 1 and 2, the *first* match
+/// (index 1) is returned — not index 0 or 2.
+#[test]
+fn select_port_idx_filter_matches_multiple_returns_first_match() {
+    let ports = ["Alpha", "BetaMIDI", "GammaMIDI"];
+    // Both ports 1 and 2 contain "midi" — port 1 must win.
+    assert_eq!(select_port_idx(&ports, Some("midi")), Some(1));
+}
+
+/// Filter is all uppercase; port names are all lowercase. Case-insensitive
+/// match must still succeed.
+#[test]
+fn select_port_idx_uppercase_filter_matches_lowercase_port() {
+    let ports = ["fluidsynth", "timidity", "usb"];
+    assert_eq!(select_port_idx(&ports, Some("FLUID")), Some(0));
+    assert_eq!(select_port_idx(&ports, Some("TIMIDITY")), Some(1));
+}
+
+/// With five ports and a non-matching filter, fallback is still index 0
+/// regardless of list length.
+#[test]
+fn select_port_idx_fallback_with_many_ports_returns_zero() {
+    let ports = ["PortA", "PortB", "PortC", "PortD", "PortE"];
+    assert_eq!(select_port_idx(&ports, Some("ZZZ_nonexistent")), Some(0));
+}
+
+/// Filter matches exactly one port that is not index 0 in a longer list.
+#[test]
+fn select_port_idx_unique_match_not_at_zero() {
+    let ports = ["Alpha", "Beta", "SpecialSynth", "Delta", "Epsilon"];
+    assert_eq!(select_port_idx(&ports, Some("special")), Some(2));
+}

--- a/engine/tests/state.rs
+++ b/engine/tests/state.rs
@@ -778,3 +778,368 @@ fn apply_command_open_close_overlay() {
     s.apply_command(InputCommand::CloseOverlay);
     assert!(s.active_overlay.is_none());
 }
+
+// ── BUG-010: NoteDelta accumulates across repeated presses ────────────────────
+
+#[test]
+fn note_delta_up_five_times_advances_five_scale_degrees() {
+    // BUG-010: Each NoteDelta(1) should use the pending note as the base so
+    // pressing Up five times advances five scale degrees, not one.
+    let mut s = SequencerState::default();
+    s.selected_step = 0;
+    // default: C4=60, C Major. After 5 ups should be A4=69 (C→D→E→F→G→A).
+    for _ in 0..5 {
+        s.apply_command(InputCommand::NoteDelta(1));
+    }
+    match s.pending_edit {
+        PendingEdit::Note { step: 0, midi_note } => {
+            assert_eq!(midi_note, 69, "5× NoteDelta(1) from C4 in C Major should reach A4=69");
+        }
+        other => panic!("expected PendingEdit::Note at step 0, got {:?}", other),
+    }
+}
+
+#[test]
+fn note_delta_accumulates_then_confirm_commits_final_value() {
+    // BUG-010: Confirm after accumulated presses should commit the final note.
+    let mut s = SequencerState::default();
+    s.selected_step = 0;
+    // C4=60. 7 ups in C Major wraps to C5=72.
+    for _ in 0..7 {
+        s.apply_command(InputCommand::NoteDelta(1));
+    }
+    s.apply_command(InputCommand::Confirm);
+    assert_eq!(s.steps[0].midi_note, 72, "Confirm after 7 NoteDelta(1) from C4 should write C5=72");
+    assert!(matches!(s.pending_edit, PendingEdit::None));
+}
+
+// ── BUG-011: ParamValueDelta seeds from committed state value ─────────────────
+
+#[test]
+fn param_value_delta_key_seeds_from_committed_key_index() {
+    // BUG-011: When state.key=D (index 2) and we press Up, pending value should
+    // be 3 (D#), not 1 (would be 0+1 if seeded from 0).
+    let mut s = SequencerState::default();
+    s.key = Key::D; // index 2
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 0; // Key param
+    s.apply_command(InputCommand::ParamValueDelta(1));
+    match s.pending_edit {
+        PendingEdit::Param { index: 0, value, .. } => {
+            assert_eq!(value, 3, "D(2)+1 should give index 3 (D#), not 1");
+        }
+        other => panic!("expected PendingEdit::Param index 0, got {:?}", other),
+    }
+}
+
+#[test]
+fn param_value_delta_swing_seeds_from_committed_swing_value() {
+    // BUG-011: When state.swing=20 and delta=-5, pending should be 15, not -5.
+    let mut s = SequencerState::default();
+    s.swing = 20;
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 2; // Swing param
+    s.apply_command(InputCommand::ParamValueDelta(-5));
+    match s.pending_edit {
+        PendingEdit::Param { index: 2, value, .. } => {
+            assert_eq!(value, 15, "swing(20)+(-5) should give 15, not -5");
+        }
+        other => panic!("expected PendingEdit::Param index 2, got {:?}", other),
+    }
+}
+
+// ── BUG-012: Confirm applies pending param change to state field ───────────────
+
+#[test]
+fn confirm_param_key_applies_to_state_key() {
+    // BUG-012: Confirming a key param edit must update state.key.
+    let mut s = SequencerState::default();
+    assert!(matches!(s.key, Key::C));
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 0;
+    // Press Up 3 times from C(0): C→C#→D→D# (index 3).
+    for _ in 0..3 {
+        s.apply_command(InputCommand::ParamValueDelta(1));
+    }
+    s.apply_command(InputCommand::Confirm);
+    assert!(matches!(s.key, Key::Ds), "key should be D# after confirming +3 from C");
+    assert!(matches!(s.pending_edit, PendingEdit::None));
+}
+
+#[test]
+fn confirm_param_swing_applies_to_state_swing() {
+    // BUG-012: Confirming a swing param edit must update state.swing.
+    let mut s = SequencerState::default();
+    assert_eq!(s.swing, 0);
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 2;
+    s.apply_command(InputCommand::ParamValueDelta(15));
+    s.apply_command(InputCommand::Confirm);
+    assert_eq!(s.swing, 15, "swing should be 15 after confirming +15 from 0");
+    assert!(matches!(s.pending_edit, PendingEdit::None));
+}
+
+#[test]
+fn confirm_param_mode_applies_to_state_mode() {
+    // BUG-012: Confirming a mode param edit must update state.mode.
+    let mut s = SequencerState::default();
+    assert!(matches!(s.mode, Mode::Major)); // index 0
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 1;
+    s.apply_command(InputCommand::ParamValueDelta(2)); // Major(0) + 2 = Dorian(2)
+    s.apply_command(InputCommand::Confirm);
+    assert!(matches!(s.mode, Mode::Dorian), "mode should be Dorian after confirming +2 from Major");
+    assert!(matches!(s.pending_edit, PendingEdit::None));
+}
+
+#[test]
+fn confirm_param_step_size_applies_to_state() {
+    // BUG-012: Confirming a step_size param edit must update state.step_size.
+    let mut s = SequencerState::default();
+    assert!(matches!(s.step_size, StepSize::Sixteenth)); // index 4
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 3;
+    s.apply_command(InputCommand::ParamValueDelta(1)); // Sixteenth(4) + 1 = ThirtySecond(5)
+    s.apply_command(InputCommand::Confirm);
+    assert!(matches!(s.step_size, StepSize::ThirtySecond), "step_size should be ThirtySecond after +1");
+    assert!(matches!(s.pending_edit, PendingEdit::None));
+}
+
+#[test]
+fn confirm_param_loop_in_applies_to_state() {
+    // BUG-012: Confirming a loop_in param edit (index 4) must update state.loop_in.
+    let mut s = SequencerState::default();
+    assert_eq!(s.loop_in, 0, "default loop_in should be 0");
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 4; // Loop param (loop_in)
+    s.apply_command(InputCommand::ParamValueDelta(5)); // 0 + 5 = 5
+    s.apply_command(InputCommand::Confirm);
+    assert_eq!(s.loop_in, 5, "loop_in should be 5 after confirming +5 from 0");
+    assert!(matches!(s.pending_edit, PendingEdit::None));
+}
+
+#[test]
+fn confirm_param_loop_in_clamps_at_15() {
+    // BUG-012: loop_in is clamped to 0..=15 by clamped_param_value.
+    let mut s = SequencerState::default();
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 4;
+    s.apply_command(InputCommand::ParamValueDelta(20)); // 0 + 20 → clamped to 15
+    s.apply_command(InputCommand::Confirm);
+    assert_eq!(s.loop_in, 15, "loop_in should clamp at 15 for delta=20");
+    assert!(matches!(s.pending_edit, PendingEdit::None));
+}
+
+#[test]
+fn confirm_param_paused_applies_to_state() {
+    // BUG-012: Confirming a paused param edit (index 6) must update state.paused.
+    // Param mapping: 0=Key,1=Mode,2=Swing,3=StepSize,4=loop_in,5=loop_out,
+    //                6=paused,7=playing.
+    let mut s = SequencerState::default();
+    assert!(!s.paused, "default paused should be false");
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 6; // Pause param
+    s.apply_command(InputCommand::ParamValueDelta(1)); // 0 + 1 = 1 (paused=true)
+    s.apply_command(InputCommand::Confirm);
+    assert!(s.paused, "paused should be true after confirming value=1");
+    assert!(matches!(s.pending_edit, PendingEdit::None));
+}
+
+#[test]
+fn confirm_param_paused_false_applies_to_state() {
+    // BUG-012: Confirming paused=false (index 6, value 0) turns off paused.
+    let mut s = SequencerState::default();
+    s.paused = true; // start paused
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 6;
+    // committed value = 1 (paused). Delta -1 → 0 (clamped to [0,1]).
+    s.apply_command(InputCommand::ParamValueDelta(-1));
+    s.apply_command(InputCommand::Confirm);
+    assert!(!s.paused, "paused should be false after confirming value=0");
+    assert!(matches!(s.pending_edit, PendingEdit::None));
+}
+
+#[test]
+fn confirm_param_playing_while_paused_leaves_tick_non_firing() {
+    // apply_param_value(7, 1) sets playing=true AND clears paused (BUG-017 fix).
+    // When both playing=true and paused=false after confirm, tick() fires.
+    // Param mapping: index 7 = playing.
+    let mut s = SequencerState::default();
+    s.paused = true;
+    s.playing = false;
+    s.steps[1].enabled = true;
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 7; // Stop/Start param
+    // committed value = 0 (not playing). Delta +1 → value=1 (playing=true).
+    s.apply_command(InputCommand::ParamValueDelta(1));
+    s.apply_command(InputCommand::Confirm);
+    // After confirm: playing=true was applied and BUG-017 fix clears paused.
+    assert!(s.playing, "playing should be true after confirming value=1");
+    // paused was cleared by the BUG-017 fix in apply_param_value(7, 1).
+    assert!(!s.paused, "paused should be cleared when playing is set via overlay (BUG-017)");
+}
+
+// ── BUG-004: tick() uses step.velocity, not hardcoded 100 ────────────────────
+
+#[test]
+fn tick_velocity_127_produces_note_on_127() {
+    // tick() must pass step.velocity=127 (maximum) through to NoteOn.
+    let mut s = SequencerState::default();
+    s.playing = true;
+    s.steps[1].enabled = true;
+    s.steps[1].midi_note = 60;
+    s.steps[1].velocity = 127;
+    s.playhead = 0;
+    let evt = s.tick();
+    assert_eq!(
+        evt,
+        Some(MidiEvent::NoteOn { channel: 0, note: 60, velocity: 127, duration_nanos: 0 }),
+        "NoteOn velocity must be 127 when step.velocity=127"
+    );
+}
+
+#[test]
+fn tick_velocity_default_100_produces_note_on_100() {
+    // tick() must pass step.velocity=100 (default) through to NoteOn.
+    let mut s = SequencerState::default();
+    s.playing = true;
+    s.steps[1].enabled = true;
+    s.steps[1].midi_note = 60;
+    // velocity is default 100
+    s.playhead = 0;
+    let evt = s.tick();
+    assert_eq!(
+        evt,
+        Some(MidiEvent::NoteOn { channel: 0, note: 60, velocity: 100, duration_nanos: 0 }),
+        "NoteOn velocity must be 100 when step.velocity is default"
+    );
+}
+
+#[test]
+fn tick_velocity_zero_produces_note_on_0() {
+    // tick() must pass step.velocity=0 through to NoteOn (not substitute 100).
+    let mut s = SequencerState::default();
+    s.playing = true;
+    s.steps[1].enabled = true;
+    s.steps[1].midi_note = 60;
+    s.steps[1].velocity = 0;
+    s.playhead = 0;
+    let evt = s.tick();
+    assert_eq!(
+        evt,
+        Some(MidiEvent::NoteOn { channel: 0, note: 60, velocity: 0, duration_nanos: 0 }),
+        "NoteOn velocity must be 0 when step.velocity=0"
+    );
+}
+
+#[test]
+fn tick_velocity_preserved_after_velocity_edit_committed() {
+    // After committing a VelocityDelta via Confirm, tick() uses the new velocity.
+    let mut s = SequencerState::default();
+    s.playing = true;
+    s.selected_step = 1;
+    s.steps[1].enabled = true;
+    s.steps[1].midi_note = 60;
+    // Default velocity=100. Set to 55 via apply_command path.
+    s.apply_command(InputCommand::VelocityDelta(-45)); // 100 - 45 = 55
+    s.apply_command(InputCommand::Confirm);
+    assert_eq!(s.steps[1].velocity, 55, "velocity should be 55 after commit");
+    s.playhead = 0;
+    let evt = s.tick();
+    assert_eq!(
+        evt,
+        Some(MidiEvent::NoteOn { channel: 0, note: 60, velocity: 55, duration_nanos: 0 }),
+        "tick() must use committed velocity=55"
+    );
+}
+
+// ── BUG-010: additional NoteDelta accumulation edge cases ─────────────────────
+
+#[test]
+fn note_delta_down_from_pending_not_committed_base() {
+    // BUG-010: After one NoteDelta(1) → pending=D4=62, a subsequent NoteDelta(-1)
+    // should go back to C4=60 using the pending note as base, not the committed note.
+    let mut s = SequencerState::default();
+    s.selected_step = 0;
+    // step: C4=60
+    s.apply_command(InputCommand::NoteDelta(1)); // C→D, pending=62
+    s.apply_command(InputCommand::NoteDelta(-1)); // D→C, pending=60
+    match s.pending_edit {
+        PendingEdit::Note { step: 0, midi_note } => {
+            assert_eq!(midi_note, 60, "NoteDelta(-1) after +1 should return to C4=60");
+        }
+        other => panic!("expected PendingEdit::Note at step 0, got {:?}", other),
+    }
+}
+
+#[test]
+fn note_delta_resets_base_when_step_changes() {
+    // After changing selected_step, the pending edit for the old step is cleared.
+    // A new NoteDelta on the new step must use the committed note of that step.
+    let mut s = SequencerState::default();
+    s.steps[0].midi_note = 60; // C4
+    s.steps[3].midi_note = 67; // G4
+    s.selected_step = 0;
+    s.apply_command(InputCommand::NoteDelta(3)); // C→E→F→G? let's just check clearing
+    s.apply_command(InputCommand::StepSelect(3)); // pending cleared
+    assert!(matches!(s.pending_edit, PendingEdit::None), "StepSelect must clear pending note");
+    // Now delta on step 3 must use step 3's committed note (G4=67).
+    s.apply_command(InputCommand::NoteDelta(1)); // G4 → next scale degree
+    match s.pending_edit {
+        PendingEdit::Note { step: 3, midi_note } => {
+            // G4=67 in C Major, +1 = A4=69
+            assert_eq!(midi_note, 69, "NoteDelta(1) from G4=67 in C Major should give A4=69");
+        }
+        other => panic!("expected PendingEdit::Note at step 3, got {:?}", other),
+    }
+}
+
+// ── BUG-011: ParamValueDelta additional seeding tests ────────────────────────
+
+#[test]
+fn param_value_delta_mode_seeds_from_committed_mode_index() {
+    // BUG-011: When state.mode=Dorian (index 2) and delta=+1, pending should be 3 (Phrygian).
+    let mut s = SequencerState::default();
+    s.mode = Mode::Dorian; // index 2
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 1; // Mode param
+    s.apply_command(InputCommand::ParamValueDelta(1));
+    match s.pending_edit {
+        PendingEdit::Param { index: 1, value, .. } => {
+            assert_eq!(value, 3, "Dorian(2)+1 should give index 3 (Phrygian)");
+        }
+        other => panic!("expected PendingEdit::Param index 1, got {:?}", other),
+    }
+}
+
+#[test]
+fn param_value_delta_step_size_seeds_from_committed_value() {
+    // BUG-011: When state.step_size=Eighth (index 3) and delta=+1, pending should be 4 (Sixteenth).
+    let mut s = SequencerState::default();
+    s.step_size = StepSize::Eighth; // index 3
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 3; // StepSize param
+    s.apply_command(InputCommand::ParamValueDelta(1));
+    match s.pending_edit {
+        PendingEdit::Param { index: 3, value, .. } => {
+            assert_eq!(value, 4, "Eighth(3)+1 should give index 4 (Sixteenth)");
+        }
+        other => panic!("expected PendingEdit::Param index 3, got {:?}", other),
+    }
+}
+
+#[test]
+fn param_value_delta_loop_in_seeds_from_committed_loop_in() {
+    // BUG-011: When state.loop_in=8 and delta=+2, pending should be 10 (not 2).
+    let mut s = SequencerState::default();
+    s.loop_in = 8;
+    s.active_overlay = Some(OverlayMode::Regular);
+    s.selected_param = 4; // Loop param
+    s.apply_command(InputCommand::ParamValueDelta(2));
+    match s.pending_edit {
+        PendingEdit::Param { index: 4, value, .. } => {
+            assert_eq!(value, 10, "loop_in(8)+2 should give 10, not 2");
+        }
+        other => panic!("expected PendingEdit::Param index 4, got {:?}", other),
+    }
+}

--- a/engine/tests/state.rs
+++ b/engine/tests/state.rs
@@ -566,18 +566,20 @@ fn apply_command_param_select_sets_selected_param() {
 
 #[test]
 fn apply_command_param_select_delta_wraps_at_7() {
+    // Now 8 params (0–7): index 7 + 1 wraps to 0.
     let mut s = SequencerState::default();
-    s.selected_param = 6;
+    s.selected_param = 7;
     s.apply_command(InputCommand::ParamSelectDelta(1));
-    assert_eq!(s.selected_param, 0, "param wraps past 6 to 0");
+    assert_eq!(s.selected_param, 0, "param wraps past 7 to 0");
 }
 
 #[test]
 fn apply_command_param_select_delta_wraps_at_0() {
+    // Now 8 params (0–7): index 0 - 1 wraps to 7.
     let mut s = SequencerState::default();
     s.selected_param = 0;
     s.apply_command(InputCommand::ParamSelectDelta(-1));
-    assert_eq!(s.selected_param, 6, "param wraps below 0 to 6");
+    assert_eq!(s.selected_param, 7, "param wraps below 0 to 7");
 }
 
 #[test]
@@ -629,10 +631,10 @@ fn default_state_has_selected_param_0() {
 
 #[test]
 fn apply_command_param_select_clamps_at_6() {
-    // ParamSelect(n) should clamp n to the valid range 0–6.
+    // ParamSelect(n) should clamp n to the valid range 0–7 (8 params total).
     let mut s = SequencerState::default();
     s.apply_command(InputCommand::ParamSelect(10));
-    assert_eq!(s.selected_param, 6, "ParamSelect(10) should clamp to 6");
+    assert_eq!(s.selected_param, 7, "ParamSelect(10) should clamp to 7");
 }
 
 #[test]

--- a/engine/tests/ui.rs
+++ b/engine/tests/ui.rs
@@ -509,3 +509,151 @@ fn pending_note_edit_with_specific_midi_note_visible_in_selected_column() {
         row1
     );
 }
+
+// ── Feature-gate regression tests (BUG-007) ─────────────────────────────────
+//
+// These tests compile and run WITHOUT the `hw-io` feature.  Their existence
+// proves that `ratatui` and `ui_render` are usable without `crossterm`, which
+// is the core fix for BUG-007.
+//
+// If the Cargo.toml regression is re-introduced (ratatui default-features = true),
+// crossterm would become a non-optional dep and `cargo test -p engine` would
+// fail in environments without a real tty during link/compile, catching the bug.
+
+/// Verify that TestBackend can construct a terminal and render a frame without
+/// the `hw-io` feature.  This is the canonical compile-time + runtime proof
+/// that `ratatui` is usable without `crossterm`.
+#[test]
+fn test_backend_renders_without_hw_io_feature() {
+    // If BUG-007 were re-introduced, `ratatui` would pull in `crossterm` and
+    // this test would fail to compile or link in a headless environment.
+    let backend = TestBackend::new(80, 5);
+    let mut terminal = Terminal::new(backend).expect("TestBackend terminal must construct without hw-io");
+
+    let state = SequencerState::default();
+    terminal.draw(|frame| {
+        render_frame(frame, &state, None, 0);
+    }).expect("render_frame must complete with TestBackend and no hw-io feature");
+
+    // If we reach here, ratatui compiled and rendered without crossterm.
+    let buffer = terminal.backend().buffer().clone();
+    // Buffer must be non-empty — at least one cell should be filled.
+    let any_non_space = (0..80u16)
+        .any(|x| buffer.cell((x, 0)).map(|c| c.symbol() != " ").unwrap_or(false));
+    assert!(any_non_space, "rendered buffer must contain non-space cells (top bar must render)");
+}
+
+/// Verify that clearing and redrawing a TestBackend terminal produces the same
+/// content as the first draw — render_frame must be deterministic and
+/// side-effect-free (no hidden terminal state dependency).
+#[test]
+fn test_backend_clear_and_redraw_is_idempotent() {
+    let state = known_state();
+
+    let backend = TestBackend::new(120, 10);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+
+    terminal.draw(|frame| {
+        render_frame(frame, &state, None, 0);
+    }).expect("first draw");
+
+    let first_row0: String = (0..120)
+        .map(|x| terminal.backend().buffer().cell((x, 0)).map(|c| c.symbol().chars().next().unwrap_or(' ')).unwrap_or(' '))
+        .collect();
+
+    terminal.clear().expect("terminal clear must succeed");
+
+    terminal.draw(|frame| {
+        render_frame(frame, &state, None, 0);
+    }).expect("second draw after clear");
+
+    let second_row0: String = (0..120)
+        .map(|x| terminal.backend().buffer().cell((x, 0)).map(|c| c.symbol().chars().next().unwrap_or(' ')).unwrap_or(' '))
+        .collect();
+
+    assert_eq!(
+        first_row0, second_row0,
+        "top bar must be identical after clear-and-redraw (render must be deterministic)"
+    );
+}
+
+/// Verify that all 16 steps can be rendered — note row must contain at least
+/// 16 note-name tokens when every step is enabled.  This exercises the full
+/// step-iteration loop in render_frame without hw-io.
+#[test]
+fn all_sixteen_steps_enabled_renders_note_names_in_note_row() {
+    let mut state = SequencerState::default();
+    // Enable all 16 steps with a mix of notes to ensure the iteration loop
+    // visits every step and does not short-circuit on an empty/disabled step.
+    for (i, step) in state.steps.iter_mut().enumerate() {
+        step.enabled = true;
+        // Spread notes: C4(60), D4(62), E4(64), ... cycling every 4
+        step.midi_note = 60 + (i as u8 % 4) * 2;
+        step.velocity = 100;
+    }
+    state.playhead = 0;
+    state.selected_step = 0;
+
+    // Wide terminal so all 16 columns fit without truncation.
+    let backend = TestBackend::new(160, 10);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+
+    terminal.draw(|frame| {
+        render_frame(frame, &state, None, 0);
+    }).expect("draw with all steps enabled");
+
+    let buffer = terminal.backend().buffer().clone();
+
+    // Collect the entire note row (y=1).
+    let note_row: String = (0..160)
+        .map(|x| buffer.cell((x, 1)).map(|c| c.symbol().chars().next().unwrap_or(' ')).unwrap_or(' '))
+        .collect();
+
+    // C4 appears for steps 0, 4, 8, 12 — must appear multiple times.
+    let c4_count = note_row.matches("C4").count();
+    assert!(
+        c4_count >= 4,
+        "note row must contain 'C4' at least 4 times when steps 0,4,8,12 are C4, got: {}",
+        note_row
+    );
+}
+
+/// Verify that the indicator row (y=2) shows the enabled marker '●' for all
+/// enabled steps and the disabled marker '○' for all disabled steps when a
+/// known pattern is set.  This is the step-indicator path in render_frame.
+#[test]
+fn indicator_row_reflects_enabled_disabled_pattern() {
+    let mut state = SequencerState::default();
+    // Enable even steps, disable odd steps.
+    for (i, step) in state.steps.iter_mut().enumerate() {
+        step.enabled = i % 2 == 0;
+        step.midi_note = 60;
+        step.velocity = 100;
+    }
+    state.playhead = 0;
+    state.selected_step = 0;
+
+    let backend = TestBackend::new(160, 10);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+
+    terminal.draw(|frame| {
+        render_frame(frame, &state, None, 0);
+    }).expect("draw");
+
+    let buffer = terminal.backend().buffer().clone();
+
+    let indicator_row: String = (0..160)
+        .map(|x| buffer.cell((x, 2)).map(|c| c.symbol()).unwrap_or(""))
+        .collect();
+
+    assert!(
+        indicator_row.contains('●'),
+        "indicator row must contain '●' for enabled (even) steps, got: {}",
+        indicator_row
+    );
+    assert!(
+        indicator_row.contains('○'),
+        "indicator row must contain '○' for disabled (odd) steps, got: {}",
+        indicator_row
+    );
+}

--- a/engine/tests/ui.rs
+++ b/engine/tests/ui.rs
@@ -657,3 +657,204 @@ fn indicator_row_reflects_enabled_disabled_pattern() {
         indicator_row
     );
 }
+
+// ── BUG-011: Overlay pending param display shows human-readable labels ────────
+
+/// Collect all text from the terminal buffer (for overlay assertions).
+fn collect_all_text(backend: &TestBackend, width: u16, height: u16) -> String {
+    let buffer = backend.buffer().clone();
+    (0..height)
+        .flat_map(|y| (0..width).map(move |x| (x, y)))
+        .map(|(x, y)| buffer.cell((x, y)).map(|c| c.symbol().chars().next().unwrap_or(' ')).unwrap_or(' '))
+        .collect()
+}
+
+#[test]
+fn overlay_pending_key_shows_human_readable_label_not_raw_index() {
+    // BUG-011: When state.key=C and a pending key edit with value=3 (D#) is
+    // present, the overlay must show "D#" not "3" as the pending value.
+    let mut state = known_state();
+    state.key = Key::C; // index 0
+    // Simulate pending value=3 (D#) for param index 0 (Key).
+    state.pending_edit = PendingEdit::Param {
+        overlay: OverlayMode::Regular,
+        index: 0,
+        value: 3,
+    };
+
+    let backend = TestBackend::new(200, 12);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|frame| {
+        render_frame(frame, &state, Some(OverlayMode::Regular), 0);
+    }).expect("draw");
+
+    let all_text = collect_all_text(terminal.backend(), 200, 12);
+
+    assert!(
+        all_text.contains("D#"),
+        "overlay pending key must show 'D#' (not raw '3'), got: {}",
+        all_text
+    );
+    // Raw index "3" alone could be a false positive, but "→3" would be the
+    // bug form. The arrow display should not end with "→3".
+    assert!(
+        !all_text.contains("→3"),
+        "overlay must NOT show '→3' (raw index) for pending key, got: {}",
+        all_text
+    );
+}
+
+#[test]
+fn overlay_pending_mode_shows_human_readable_label_not_raw_index() {
+    // BUG-011: pending mode edit value=2 (Dorian) must show "Dorian" not "2".
+    let mut state = known_state();
+    state.mode = Mode::Major; // index 0
+    state.pending_edit = PendingEdit::Param {
+        overlay: OverlayMode::Regular,
+        index: 1,
+        value: 2, // Dorian
+    };
+
+    let backend = TestBackend::new(200, 12);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|frame| {
+        render_frame(frame, &state, Some(OverlayMode::Regular), 1);
+    }).expect("draw");
+
+    let all_text = collect_all_text(terminal.backend(), 200, 12);
+
+    assert!(
+        all_text.contains("Dorian"),
+        "overlay pending mode must show 'Dorian' (not '2'), got: {}",
+        all_text
+    );
+    assert!(
+        !all_text.contains("→2"),
+        "overlay must NOT show '→2' (raw index) for pending mode, got: {}",
+        all_text
+    );
+}
+
+#[test]
+fn overlay_pending_swing_shows_formatted_value_not_raw() {
+    // BUG-011: pending swing edit value=+15 must show "+15" not "15" or a raw delta.
+    let mut state = known_state();
+    state.swing = 0;
+    state.pending_edit = PendingEdit::Param {
+        overlay: OverlayMode::Regular,
+        index: 2,
+        value: 15, // swing=+15
+    };
+
+    let backend = TestBackend::new(200, 12);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|frame| {
+        render_frame(frame, &state, Some(OverlayMode::Regular), 2);
+    }).expect("draw");
+
+    let all_text = collect_all_text(terminal.backend(), 200, 12);
+
+    // The pending_param_value_string for swing formats as "{:+}", so +15.
+    assert!(
+        all_text.contains("+15"),
+        "overlay pending swing must show '+15', got: {}",
+        all_text
+    );
+}
+
+#[test]
+fn overlay_pending_step_size_shows_label_not_raw_index() {
+    // BUG-011: pending step_size edit value=3 (Eighth) must show "1/8" not "3".
+    let mut state = known_state();
+    state.step_size = StepSize::Sixteenth; // index 4
+    state.pending_edit = PendingEdit::Param {
+        overlay: OverlayMode::Regular,
+        index: 3,
+        value: 3, // Eighth → "1/8"
+    };
+
+    let backend = TestBackend::new(200, 12);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|frame| {
+        render_frame(frame, &state, Some(OverlayMode::Regular), 3);
+    }).expect("draw");
+
+    let all_text = collect_all_text(terminal.backend(), 200, 12);
+
+    assert!(
+        all_text.contains("1/8"),
+        "overlay pending step_size must show '1/8' (not '3'), got: {}",
+        all_text
+    );
+    assert!(
+        !all_text.contains("→3"),
+        "overlay must NOT show '→3' (raw index) for pending step_size, got: {}",
+        all_text
+    );
+}
+
+#[test]
+fn overlay_pending_playing_shows_label_not_raw_integer() {
+    // BUG-011: pending playing param edit value=1 must show "playing" not "1".
+    // Index 7 = playing in the base param mapping (0=Key,1=Mode,2=Swing,3=StepSize,
+    // 4=loop_in,5=loop_out,6=paused,7=playing).
+    let mut state = known_state();
+    state.playing = false; // committed: "stopped"
+    state.pending_edit = PendingEdit::Param {
+        overlay: OverlayMode::Regular,
+        index: 7,
+        value: 1, // playing=true
+    };
+
+    let backend = TestBackend::new(200, 12);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|frame| {
+        render_frame(frame, &state, Some(OverlayMode::Regular), 7);
+    }).expect("draw");
+
+    let all_text = collect_all_text(terminal.backend(), 200, 12);
+
+    assert!(
+        all_text.contains("playing"),
+        "overlay pending playing must show 'playing' (not '1'), got: {}",
+        all_text
+    );
+    assert!(
+        !all_text.contains("→1"),
+        "overlay must NOT show '→1' (raw integer) for pending playing, got: {}",
+        all_text
+    );
+}
+
+#[test]
+fn overlay_pending_paused_shows_on_not_raw_integer() {
+    // BUG-011: pending paused param edit value=1 must show "on" not "1".
+    // Index 6 = paused in the base param mapping (0=Key,1=Mode,2=Swing,3=StepSize,
+    // 4=loop_in,5=loop_out,6=paused,7=playing).
+    let mut state = known_state();
+    state.paused = false; // committed: "off"
+    state.pending_edit = PendingEdit::Param {
+        overlay: OverlayMode::Regular,
+        index: 6,
+        value: 1, // paused=true
+    };
+
+    let backend = TestBackend::new(200, 12);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+    terminal.draw(|frame| {
+        render_frame(frame, &state, Some(OverlayMode::Regular), 6);
+    }).expect("draw");
+
+    let all_text = collect_all_text(terminal.backend(), 200, 12);
+
+    assert!(
+        all_text.contains("on"),
+        "overlay pending paused must show 'on' (not '1'), got: {}",
+        all_text
+    );
+    assert!(
+        !all_text.contains("→1"),
+        "overlay must NOT show '→1' (raw integer) for pending paused, got: {}",
+        all_text
+    );
+}


### PR DESCRIPTION
## Summary

- **BUG-001**: firmware release profile now strips debug symbols (`[profile.firmware-release]` in `Cargo.toml`)
- **BUG-002**: `clock::add_nanos_signed` correctly handles second-boundary borrows (negative offsets that cross the nanosecond epoch)
- **BUG-003**: `.cargo/config.toml` `/tmp` paths removed; local-override pattern documented with `config.local.toml` and `.gitignore` entry
- **BUG-004**: `tick()` uses `step.velocity` instead of hardcoded 100
- **BUG-005**: `unsafe transmute` replaced with `offset_of!` in HID tests
- **BUG-006**: `run_hid` zeroes buffer each iteration to prevent stale bytes
- **BUG-007**: `ratatui` crossterm backend gated behind `hw-io` feature
- **BUG-008**: CLI args `--midi-port`/`--hid-vid`/`--hid-pid` forwarded to thread functions
- **BUG-009**: all threads joined on shutdown; clock thread skipped in non-`hw-io` builds
- **BUG-010**: `NoteDelta` accumulates across keypresses using pending note as base
- **BUG-011**: overlay param display shows human-readable labels instead of raw numbers
- **BUG-012**: overlay Confirm actually writes param changes to state fields
- **BUG-013**: `.cargo/config.toml` comment fixed to reference `--config` flag
- **BUG-014**: `loop_out` has its own edit slot in the Regular Overlay (8 params total)
- **BUG-015**: dead `open_device()` function removed from `hid.rs`
- **BUG-016**: `choose_midi_port` warns when filter matches no ports
- **BUG-017**: overlay Confirm sets `playing=true` and clears `paused`

## Architectural decisions

- All fixes target the `engine` crate only; no changes to protocol or workspace topology.
- HID stale-byte fix (BUG-006) uses a simple `buf = [0u8; 64]` reset at top of loop — no allocation.
- Param overlay seeding (BUG-011/012) reads directly from `State` fields so the display and confirm paths share the same source of truth.

## Test coverage

All fixes are covered by unit/integration tests in `engine/tests/`. 253 tests pass (`cargo test -p engine`). No external I/O is exercised in the test suite — MIDI and HID boundaries are stubbed via channels and in-memory structs.

## Known limitations / follow-up

- BUG-008/009 (CLI arg forwarding, thread join) are verified via `main_wiring` integration tests that inspect CLI parsing and channel wiring; the actual hardware paths are not exercised in CI.
- No changes to the TUI key-binding layer; shift-overlay param editing is still marked "coming soon" in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)