### PR TITLE
feat(engine): Shift overlay UI with SHIFT_PARAMS, value helpers, and action label

### DIFF
--- a/engine/src/ui_render.rs
+++ b/engine/src/ui_render.rs
@@ -17,8 +17,20 @@ use ratatui::Frame;
 
 use crate::input::OverlayMode;
 use crate::music_theory::note_name;
-use crate::state::{PendingEdit, SequencerState, StepSize};
+use crate::state::{PendingEdit, SequencerState, StepSize, TempoRollPoint, TempoRandType};
 use crate::music_theory::{Key, Mode};
+
+/// Shift overlay parameter names (index 0–7).
+pub const SHIFT_PARAMS: [&str; 8] = [
+    "Note Rnd",    // 0 — note_rand (0–100)
+    "Tempo Rnd",   // 1 — tempo_rand (0–100)
+    "Roll Point",  // 2 — tempo_roll_point enum
+    "Var Max",     // 3 — tempo_variance_max (1–99)
+    "Tempo Type",  // 4 — tempo_rand_type enum
+    "Step Rnd",    // 5 — step_rand (0–100)
+    "Scale Quant", // 6 — scale_quant bool
+    "(reserved)",  // 7 — Key Transposition if accepted; empty for now
+];
 
 /// Regular overlay parameter names (index 0–7).
 pub const REGULAR_PARAMS: [&str; 8] = [
@@ -102,7 +114,13 @@ pub fn render_frame(
     let area = frame.area();
 
     // Vertical split: top bar | step rows | info row | overlay panel (if active)
-    let overlay_height = if overlay.is_some() { 3u16 } else { 0u16 };
+    // Shift overlay needs height 4 (border top + param row + action row + border bottom).
+    // Regular overlay needs height 3 (border top + param row + border bottom).
+    let overlay_height = match overlay {
+        None => 0u16,
+        Some(OverlayMode::Shift) => 4u16,
+        Some(OverlayMode::Regular) => 3u16,
+    };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -244,8 +262,50 @@ fn render_overlay(
     match overlay {
         None => {}
         Some(OverlayMode::Shift) => {
-            let para = Paragraph::new("(shift mode — coming soon)")
-                .block(Block::default().title("Shift Overlay").borders(Borders::ALL));
+            let pending_param_value: Option<(u8, i64)> = match state.pending_edit {
+                PendingEdit::Param { overlay: OverlayMode::Shift, index, value } => {
+                    Some((index, value))
+                }
+                _ => None,
+            };
+
+            let mut spans: Vec<Span> = Vec::with_capacity(8 * 3);
+            for (i, name) in SHIFT_PARAMS.iter().enumerate() {
+                let idx = i as u8;
+                let is_highlighted = idx == selected_param;
+
+                let value_str = shift_param_value_string(state, idx);
+                let display = if let Some((pi, pv)) = pending_param_value {
+                    if pi == idx {
+                        let pending_str = shift_pending_param_value_string(idx, pv);
+                        format!(" {}[{}→{}] ", name, value_str, pending_str)
+                    } else {
+                        format!(" {}:{} ", name, value_str)
+                    }
+                } else {
+                    format!(" {}:{} ", name, value_str)
+                };
+
+                let style = if is_highlighted && idx < 7 {
+                    Style::default().add_modifier(Modifier::BOLD | Modifier::REVERSED)
+                } else if idx == 7 {
+                    Style::default().add_modifier(Modifier::DIM)
+                } else {
+                    Style::default()
+                };
+                spans.push(Span::styled(display, style));
+                if i < SHIFT_PARAMS.len() - 1 {
+                    spans.push(Span::raw("|"));
+                }
+            }
+
+            let action_label = Line::from(Span::styled(
+                "  [S]kip  [G]en",
+                Style::default().add_modifier(Modifier::DIM),
+            ));
+            let param_line = Line::from(spans);
+            let para = Paragraph::new(vec![param_line, action_label])
+                .block(Block::default().title("Shift Overlay (Esc to close)").borders(Borders::ALL));
             frame.render_widget(para, area);
         }
         Some(OverlayMode::Regular) => {
@@ -291,6 +351,59 @@ fn render_overlay(
                 .block(Block::default().title("Regular Overlay (Esc to close)").borders(Borders::ALL));
             frame.render_widget(para, area);
         }
+    }
+}
+
+/// Return the display string for shift param `index` given the current state.
+///
+/// Index map: 0=note_rand, 1=tempo_rand, 2=tempo_roll_point, 3=tempo_variance_max,
+/// 4=tempo_rand_type, 5=step_rand, 6=scale_quant, 7=reserved.
+pub fn shift_param_value_string(state: &SequencerState, index: u8) -> String {
+    match index {
+        0 => state.note_rand.to_string(),
+        1 => state.tempo_rand.to_string(),
+        2 => tempo_roll_point_name(state.tempo_roll_point).to_string(),
+        3 => state.tempo_variance_max.to_string(),
+        4 => tempo_rand_type_name(state.tempo_rand_type).to_string(),
+        5 => state.step_rand.to_string(),
+        6 => if state.scale_quant { "On".to_string() } else { "Off".to_string() },
+        _ => "\u{2014}".to_string(), // em dash for reserved
+    }
+}
+
+/// Return the display string for a pending shift param edit.
+///
+/// `v` is the raw `i64` from `PendingEdit::Param { value, .. }`.
+/// Index map: 0=note_rand, 1=tempo_rand, 2=tempo_roll_point, 3=tempo_variance_max,
+/// 4=tempo_rand_type, 5=step_rand, 6=scale_quant, 7=reserved.
+pub fn shift_pending_param_value_string(index: u8, v: i64) -> String {
+    match index {
+        0 | 1 | 3 | 5 => format!("{}", v),
+        2 => tempo_roll_point_name(TempoRollPoint::from_index(v as usize)).to_string(),
+        4 => tempo_rand_type_name(TempoRandType::from_index(v as usize)).to_string(),
+        6 => if v != 0 { "On".to_string() } else { "Off".to_string() },
+        _ => "\u{2014}".to_string(), // em dash for reserved
+    }
+}
+
+/// Return a human-readable string for a `TempoRollPoint`.
+fn tempo_roll_point_name(trp: TempoRollPoint) -> &'static str {
+    match trp {
+        TempoRollPoint::Off  => "Off",
+        TempoRollPoint::Step => "Step",
+        TempoRollPoint::Beat => "Beat",
+        TempoRollPoint::Seq  => "Seq",
+    }
+}
+
+/// Return a human-readable string for a `TempoRandType`.
+fn tempo_rand_type_name(trt: TempoRandType) -> &'static str {
+    match trt {
+        TempoRandType::Random   => "Random",
+        TempoRandType::Up       => "Up",
+        TempoRandType::Down     => "Down",
+        TempoRandType::Breathe  => "Breathe",
+        TempoRandType::PingPong => "PingPong",
     }
 }
 

--- a/engine/tests/ui.rs
+++ b/engine/tests/ui.rs
@@ -3,8 +3,8 @@ use ratatui::Terminal;
 
 use engine::input::OverlayMode;
 use engine::music_theory::{Key, Mode};
-use engine::state::{PendingEdit, SequencerState, StepData, StepSize};
-use engine::ui_render::render_frame;
+use engine::state::{PendingEdit, SequencerState, StepData, StepSize, TempoRollPoint, TempoRandType};
+use engine::ui_render::{render_frame, shift_param_value_string, shift_pending_param_value_string};
 
 /// Build a known state: step 0 = C4 enabled, playhead=0, 120 BPM, C Major, PLAYING.
 fn known_state() -> SequencerState {
@@ -146,9 +146,14 @@ fn overlay_shift_shows_coming_soon() {
         .map(|(x, y)| buffer.cell((x, y)).map(|c| c.symbol().chars().next().unwrap_or(' ')).unwrap_or(' '))
         .collect();
 
+    // Verify real shift overlay rendered (not the old placeholder).
     assert!(
-        all_text.contains("shift mode"),
-        "shift overlay must contain 'shift mode', got buffer text"
+        all_text.contains("Shift Overlay"),
+        "shift overlay must contain 'Shift Overlay', got buffer text"
+    );
+    assert!(
+        all_text.contains("Note Rnd"),
+        "shift overlay must show SHIFT_PARAMS[0]='Note Rnd', got buffer text"
     );
 }
 
@@ -455,12 +460,12 @@ fn overlay_regular_selected_param_2_shows_swing_highlighted() {
     );
 }
 
-// --- Overlay: F2 Shift shows "(shift mode" text ---
+// --- Overlay: Shift overlay renders all 8 SHIFT_PARAMS and action label ---
 
 #[test]
 fn overlay_shift_shows_shift_mode_text() {
     let state = known_state();
-    let backend = TestBackend::new(120, 12);
+    let backend = TestBackend::new(200, 12);
     let mut terminal = Terminal::new(backend).expect("test terminal");
 
     terminal.draw(|frame| {
@@ -470,13 +475,26 @@ fn overlay_shift_shows_shift_mode_text() {
     let buffer = terminal.backend().buffer().clone();
 
     let all_text: String = (0..12u16)
-        .flat_map(|y| (0..120u16).map(move |x| (x, y)))
+        .flat_map(|y| (0..200u16).map(move |x| (x, y)))
         .map(|(x, y)| buffer.cell((x, y)).map(|c| c.symbol().chars().next().unwrap_or(' ')).unwrap_or(' '))
         .collect();
 
+    // All 8 shift param names must be visible.
+    for name in engine::ui_render::SHIFT_PARAMS.iter() {
+        assert!(
+            all_text.contains(name),
+            "shift overlay must contain SHIFT_PARAMS entry '{name}', got buffer text"
+        );
+    }
+
+    // Action label row must be visible.
     assert!(
-        all_text.contains("shift mode"),
-        "shift overlay must contain '(shift mode', got buffer text"
+        all_text.contains("[S]kip") || all_text.contains("Skip"),
+        "shift overlay must show skip action label, got buffer text"
+    );
+    assert!(
+        all_text.contains("[G]en") || all_text.contains("Gen"),
+        "shift overlay must show gen action label, got buffer text"
     );
 }
 
@@ -857,4 +875,166 @@ fn overlay_pending_paused_shows_on_not_raw_integer() {
         "overlay must NOT show '→1' (raw integer) for pending paused, got: {}",
         all_text
     );
+}
+
+// ─── shift_param_value_string unit tests ─────────────────────────────────────
+
+#[test]
+fn shift_param_value_string_note_rand() {
+    let mut s = SequencerState::default();
+    s.note_rand = 42;
+    assert_eq!(shift_param_value_string(&s, 0), "42");
+}
+
+#[test]
+fn shift_param_value_string_tempo_rand() {
+    let mut s = SequencerState::default();
+    s.tempo_rand = 75;
+    assert_eq!(shift_param_value_string(&s, 1), "75");
+}
+
+#[test]
+fn shift_param_value_string_roll_point_variants() {
+    let mut s = SequencerState::default();
+    s.tempo_roll_point = TempoRollPoint::Off;
+    assert_eq!(shift_param_value_string(&s, 2), "Off");
+    s.tempo_roll_point = TempoRollPoint::Step;
+    assert_eq!(shift_param_value_string(&s, 2), "Step");
+    s.tempo_roll_point = TempoRollPoint::Beat;
+    assert_eq!(shift_param_value_string(&s, 2), "Beat");
+    s.tempo_roll_point = TempoRollPoint::Seq;
+    assert_eq!(shift_param_value_string(&s, 2), "Seq");
+}
+
+#[test]
+fn shift_param_value_string_var_max() {
+    let mut s = SequencerState::default();
+    s.tempo_variance_max = 50;
+    assert_eq!(shift_param_value_string(&s, 3), "50");
+}
+
+#[test]
+fn shift_param_value_string_tempo_rand_type_variants() {
+    let mut s = SequencerState::default();
+    s.tempo_rand_type = TempoRandType::Random;
+    assert_eq!(shift_param_value_string(&s, 4), "Random");
+    s.tempo_rand_type = TempoRandType::Up;
+    assert_eq!(shift_param_value_string(&s, 4), "Up");
+    s.tempo_rand_type = TempoRandType::Down;
+    assert_eq!(shift_param_value_string(&s, 4), "Down");
+    s.tempo_rand_type = TempoRandType::Breathe;
+    assert_eq!(shift_param_value_string(&s, 4), "Breathe");
+    s.tempo_rand_type = TempoRandType::PingPong;
+    assert_eq!(shift_param_value_string(&s, 4), "PingPong");
+}
+
+#[test]
+fn shift_param_value_string_step_rand() {
+    let mut s = SequencerState::default();
+    s.step_rand = 33;
+    assert_eq!(shift_param_value_string(&s, 5), "33");
+}
+
+#[test]
+fn shift_param_value_string_scale_quant() {
+    let mut s = SequencerState::default();
+    s.scale_quant = false;
+    assert_eq!(shift_param_value_string(&s, 6), "Off");
+    s.scale_quant = true;
+    assert_eq!(shift_param_value_string(&s, 6), "On");
+}
+
+#[test]
+fn shift_param_value_string_reserved_returns_em_dash() {
+    let s = SequencerState::default();
+    // Index 7 is reserved; should not panic and return em dash.
+    let result = shift_param_value_string(&s, 7);
+    assert!(!result.is_empty(), "reserved param must return a non-empty string");
+}
+
+// ─── shift_pending_param_value_string unit tests ──────────────────────────────
+
+#[test]
+fn shift_pending_param_value_string_numeric() {
+    assert_eq!(shift_pending_param_value_string(0, 55), "55");
+    assert_eq!(shift_pending_param_value_string(1, 80), "80");
+    assert_eq!(shift_pending_param_value_string(3, 25), "25");
+    assert_eq!(shift_pending_param_value_string(5, 10), "10");
+}
+
+#[test]
+fn shift_pending_param_value_string_roll_point() {
+    assert_eq!(shift_pending_param_value_string(2, 0), "Off");
+    assert_eq!(shift_pending_param_value_string(2, 1), "Step");
+    assert_eq!(shift_pending_param_value_string(2, 2), "Beat");
+    assert_eq!(shift_pending_param_value_string(2, 3), "Seq");
+}
+
+#[test]
+fn shift_pending_param_value_string_tempo_rand_type() {
+    assert_eq!(shift_pending_param_value_string(4, 0), "Random");
+    assert_eq!(shift_pending_param_value_string(4, 1), "Up");
+    assert_eq!(shift_pending_param_value_string(4, 2), "Down");
+    assert_eq!(shift_pending_param_value_string(4, 3), "Breathe");
+    assert_eq!(shift_pending_param_value_string(4, 4), "PingPong");
+}
+
+#[test]
+fn shift_pending_param_value_string_scale_quant() {
+    assert_eq!(shift_pending_param_value_string(6, 0), "Off");
+    assert_eq!(shift_pending_param_value_string(6, 1), "On");
+}
+
+#[test]
+fn shift_pending_param_value_string_reserved_does_not_panic() {
+    let result = shift_pending_param_value_string(7, 999);
+    assert!(!result.is_empty());
+}
+
+// ─── Shift overlay: pending edit displayed in overlay ────────────────────────
+
+#[test]
+fn shift_overlay_pending_edit_shown_in_render() {
+    let mut state = known_state();
+    // Set a pending edit for shift param 1 (Tempo Rnd) value=88.
+    state.pending_edit = PendingEdit::Param {
+        overlay: OverlayMode::Shift,
+        index: 1,
+        value: 88,
+    };
+
+    let backend = TestBackend::new(200, 12);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+
+    terminal.draw(|frame| {
+        render_frame(frame, &state, Some(OverlayMode::Shift), 1);
+    }).expect("draw");
+
+    let buffer = terminal.backend().buffer().clone();
+    let all_text: String = (0..12u16)
+        .flat_map(|y| (0..200u16).map(move |x| (x, y)))
+        .map(|(x, y)| buffer.cell((x, y)).map(|c| c.symbol().chars().next().unwrap_or(' ')).unwrap_or(' '))
+        .collect();
+
+    assert!(
+        all_text.contains("88"),
+        "shift overlay must show pending value 88, got: {}",
+        all_text
+    );
+}
+
+// ─── Shift overlay: render_frame with Shift overlay does not panic ────────────
+
+#[test]
+fn shift_overlay_render_frame_does_not_panic() {
+    let state = known_state();
+    let backend = TestBackend::new(200, 12);
+    let mut terminal = Terminal::new(backend).expect("test terminal");
+
+    // Must not panic for any selected_param including index 7 (reserved).
+    for sel in 0u8..=7 {
+        terminal.draw(|frame| {
+            render_frame(frame, &state, Some(OverlayMode::Shift), sel);
+        }).expect("draw must not panic");
+    }
 }


### PR DESCRIPTION
## Summary

- Replaces the `(shift mode — coming soon)` placeholder in `render_overlay` with a full 8-param span-building loop matching the Regular overlay pattern
- Adds `SHIFT_PARAMS: [&str; 8]` constant with all shift parameter names (Note Rnd, Tempo Rnd, Roll Point, Var Max, Tempo Type, Step Rnd, Scale Quant, reserved)
- Adds `shift_param_value_string(state, index)` helper returning committed display values for all 8 indices using `SequencerState` fields from Stream C
- Adds `shift_pending_param_value_string(index, v)` helper returning pending display values from raw `i64`
- Adds `[S]kip  [G]en` action label row (dimmed style) below the param row; bumps Shift overlay height from 3 to 4 rows

## Key Architectural Decisions

- Index 7 (reserved) always renders with DIM style regardless of `selected_param` — the `is_highlighted && idx < 7` guard prevents highlighting the reserved slot
- Private helpers `tempo_roll_point_name` and `tempo_rand_type_name` keep the match arms DRY between the committed and pending paths
- No new crate dependencies; uses existing `ratatui` span/style primitives

## Test Coverage

- 15 new tests in `engine/tests/ui.rs`: 8 `shift_param_value_string_*` unit tests covering every index, 5 `shift_pending_param_value_string_*` tests covering all display branches, plus `shift_overlay_pending_edit_shown_in_render` and `shift_overlay_render_frame_does_not_panic` (loops over all 8 `selected_param` values)
- Existing `overlay_shift_shows_coming_soon` and `overlay_shift_shows_shift_mode_text` tests updated to assert on new rendered content
- Full suite: 334 tests (70 unit + 45 UI integration + 219 other integration), all pass; clippy clean

## Known Limitations / Follow-up

- Index 7 (reserved) is a placeholder for Key Transposition if that feature is accepted; the display renders an em-dash for both committed and pending paths — consistent but cosmetically redundant if a pending edit is somehow set for that slot
- `shift_pending_param_value_string_reserved_does_not_panic` test asserts `!result.is_empty()` rather than the exact `"—"` string — a minor test-quality improvement could strengthen this assertion in a follow-up