### PR TITLE
feat(engine): wire Shift overlay keyboard shortcuts for s/g action commands

### DIFF
--- a/engine/src/input.rs
+++ b/engine/src/input.rs
@@ -97,6 +97,22 @@ pub fn overlay_key_to_command(key_code: KeyCodeSimple) -> Option<InputCommand> {
     }
 }
 
+/// Pure function: translate a key event to a Shift overlay action command.
+///
+/// Called only when the Shift overlay is active. Returns `None` for keys that
+/// are not Shift actions (caller falls through to `overlay_key_to_command`).
+pub fn shift_action_key_to_command(key_code: KeyCodeSimple) -> Option<InputCommand> {
+    match key_code {
+        KeyCodeSimple::Char('s') | KeyCodeSimple::Char('S') => {
+            Some(InputCommand::SkipModifierToggle)
+        }
+        KeyCodeSimple::Char('g') | KeyCodeSimple::Char('G') => {
+            Some(InputCommand::GenerateRandomSequence)
+        }
+        _ => None,
+    }
+}
+
 /// A minimal key code enum that mirrors the subset of crossterm keys we care
 /// about.  This lives in `input.rs` (no feature gate) so the translation
 /// functions can be unit-tested without the `hw-io` feature.
@@ -124,5 +140,71 @@ pub enum KeyCodeSimple {
     Char(char),
     /// Any other key (ignored).
     Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── shift_action_key_to_command ──────────────────────────────────────────
+
+    #[test]
+    fn shift_action_s_lower_maps_to_skip_modifier_toggle() {
+        let cmd = shift_action_key_to_command(KeyCodeSimple::Char('s'));
+        assert!(matches!(cmd, Some(InputCommand::SkipModifierToggle)));
+    }
+
+    #[test]
+    fn shift_action_s_upper_maps_to_skip_modifier_toggle() {
+        let cmd = shift_action_key_to_command(KeyCodeSimple::Char('S'));
+        assert!(matches!(cmd, Some(InputCommand::SkipModifierToggle)));
+    }
+
+    #[test]
+    fn shift_action_g_lower_maps_to_generate_random_sequence() {
+        let cmd = shift_action_key_to_command(KeyCodeSimple::Char('g'));
+        assert!(matches!(cmd, Some(InputCommand::GenerateRandomSequence)));
+    }
+
+    #[test]
+    fn shift_action_g_upper_maps_to_generate_random_sequence() {
+        let cmd = shift_action_key_to_command(KeyCodeSimple::Char('G'));
+        assert!(matches!(cmd, Some(InputCommand::GenerateRandomSequence)));
+    }
+
+    #[test]
+    fn shift_action_arrow_keys_return_none() {
+        assert!(shift_action_key_to_command(KeyCodeSimple::Left).is_none());
+        assert!(shift_action_key_to_command(KeyCodeSimple::Right).is_none());
+        assert!(shift_action_key_to_command(KeyCodeSimple::Up).is_none());
+        assert!(shift_action_key_to_command(KeyCodeSimple::Down).is_none());
+    }
+
+    #[test]
+    fn shift_action_enter_esc_return_none() {
+        assert!(shift_action_key_to_command(KeyCodeSimple::Enter).is_none());
+        assert!(shift_action_key_to_command(KeyCodeSimple::Esc).is_none());
+    }
+
+    #[test]
+    fn shift_action_other_chars_return_none() {
+        assert!(shift_action_key_to_command(KeyCodeSimple::Char('p')).is_none());
+        assert!(shift_action_key_to_command(KeyCodeSimple::Char('x')).is_none());
+        assert!(shift_action_key_to_command(KeyCodeSimple::Other).is_none());
+    }
+
+    // ── overlay_key_to_command fallthrough still works ───────────────────────
+
+    #[test]
+    fn overlay_key_arrows_still_work() {
+        assert!(matches!(
+            overlay_key_to_command(KeyCodeSimple::Left),
+            Some(InputCommand::ParamSelectDelta(-1))
+        ));
+        assert!(matches!(
+            overlay_key_to_command(KeyCodeSimple::Esc),
+            Some(InputCommand::CloseOverlay)
+        ));
+    }
 }
 

--- a/engine/src/input.rs
+++ b/engine/src/input.rs
@@ -46,6 +46,15 @@ pub enum InputCommand {
     ParamValueDelta(i8),
     /// Toggle playback on/off. Stopping also clears the paused flag.
     PlayStop,
+    /// Apply a semitone offset to all steps' notes.
+    /// 0 clears the modifier. Range: -96..=96 (actual semitones).
+    NoteModifierSet(i8),
+    /// Toggle per-step skip modifier on/off.
+    SkipModifierToggle,
+    /// Set velocity offset modifier (0 = off). Range: -127..=127.
+    VelocityModifierSet(i8),
+    /// Randomise all 16 step notes within the current key/mode.
+    GenerateRandomSequence,
 }
 
 /// Pure function: translate a root-mode key event into an `InputCommand`.

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -503,6 +503,18 @@ impl SequencerState {
                     self.playing = true;
                 }
             }
+            InputCommand::NoteModifierSet(s) => {
+                self.note_modifier = s;
+            }
+            InputCommand::SkipModifierToggle => {
+                self.skip_modifier = !self.skip_modifier;
+            }
+            InputCommand::VelocityModifierSet(v) => {
+                self.velocity_modifier = v;
+            }
+            InputCommand::GenerateRandomSequence => {
+                self.generate_random_sequence();
+            }
         }
     }
 
@@ -638,6 +650,22 @@ impl SequencerState {
             6 => self.scale_quant = value != 0,
             // 7: reserved — no-op.
             _ => {}
+        }
+    }
+
+    /// Randomise all 16 steps' notes to in-key values within MIDI range 48–84.
+    ///
+    /// Uses `next_rand(&mut self.rng_seed)` for each step. Enabled flags are
+    /// left unchanged — only `midi_note` is updated.
+    /// Generated note range: 48–84 (C3–C6, 3 octaves). The raw random value
+    /// is mapped to this range, then snapped to the current key/mode via
+    /// `music_theory::snap_to_key`.
+    fn generate_random_sequence(&mut self) {
+        for step in self.steps.iter_mut() {
+            let raw = next_rand(&mut self.rng_seed);
+            let note_in_range = (raw % 37) as u8 + 48; // 48..=84
+            step.midi_note =
+                crate::music_theory::snap_to_key(note_in_range, self.key, self.mode);
         }
     }
 
@@ -1362,6 +1390,177 @@ mod tests {
         state.apply_command(InputCommand::ParamValueDelta(50));
         state.apply_command(InputCommand::Confirm);
         assert_eq!(state.pending_edit, PendingEdit::None);
+    }
+
+    // ── Stream D: Shift action commands ─────────────────────────────────────
+
+    #[test]
+    fn test_note_modifier_set_applies_value() {
+        let mut state = SequencerState::default();
+        state.apply_command(InputCommand::NoteModifierSet(5));
+        assert_eq!(state.note_modifier, 5);
+    }
+
+    #[test]
+    fn test_note_modifier_set_clears_with_zero() {
+        let mut state = SequencerState::default();
+        state.note_modifier = 12;
+        state.apply_command(InputCommand::NoteModifierSet(0));
+        assert_eq!(state.note_modifier, 0);
+    }
+
+    #[test]
+    fn test_note_modifier_set_negative_value() {
+        let mut state = SequencerState::default();
+        state.apply_command(InputCommand::NoteModifierSet(-24));
+        assert_eq!(state.note_modifier, -24);
+    }
+
+    #[test]
+    fn test_skip_modifier_toggle_false_to_true() {
+        let mut state = SequencerState::default();
+        assert!(!state.skip_modifier);
+        state.apply_command(InputCommand::SkipModifierToggle);
+        assert!(state.skip_modifier);
+    }
+
+    #[test]
+    fn test_skip_modifier_toggle_true_to_false() {
+        let mut state = SequencerState::default();
+        state.skip_modifier = true;
+        state.apply_command(InputCommand::SkipModifierToggle);
+        assert!(!state.skip_modifier);
+    }
+
+    #[test]
+    fn test_skip_modifier_toggle_round_trip() {
+        let mut state = SequencerState::default();
+        state.apply_command(InputCommand::SkipModifierToggle);
+        state.apply_command(InputCommand::SkipModifierToggle);
+        assert!(!state.skip_modifier, "double toggle should return to false");
+    }
+
+    #[test]
+    fn test_velocity_modifier_set_applies_value() {
+        let mut state = SequencerState::default();
+        state.apply_command(InputCommand::VelocityModifierSet(64));
+        assert_eq!(state.velocity_modifier, 64);
+    }
+
+    #[test]
+    fn test_velocity_modifier_set_clears_with_zero() {
+        let mut state = SequencerState::default();
+        state.velocity_modifier = 50;
+        state.apply_command(InputCommand::VelocityModifierSet(0));
+        assert_eq!(state.velocity_modifier, 0);
+    }
+
+    #[test]
+    fn test_velocity_modifier_set_negative_value() {
+        let mut state = SequencerState::default();
+        state.apply_command(InputCommand::VelocityModifierSet(-127));
+        assert_eq!(state.velocity_modifier, -127);
+    }
+
+    #[test]
+    fn test_generate_random_sequence_updates_all_notes() {
+        let mut state = SequencerState::default();
+        // Set all notes to 60 (C4) first so we can detect changes.
+        for step in state.steps.iter_mut() {
+            step.midi_note = 60;
+        }
+        // Record original enabled flags.
+        let enabled_before: [bool; 16] = core::array::from_fn(|i| state.steps[i].enabled);
+        state.apply_command(InputCommand::GenerateRandomSequence);
+        // All 16 notes must have been set (may or may not differ from 60 —
+        // verify they are in range and in key).
+        for (i, step) in state.steps.iter().enumerate() {
+            assert!(
+                step.midi_note >= 48 && step.midi_note <= 84,
+                "step {i} midi_note {} out of range 48–84",
+                step.midi_note
+            );
+            // Identity check: snapping again must produce the same note.
+            let snapped = crate::music_theory::snap_to_key(step.midi_note, state.key, state.mode);
+            assert_eq!(
+                step.midi_note, snapped,
+                "step {i} note {} is not in key/mode",
+                step.midi_note
+            );
+            // Enabled flag must be unchanged.
+            assert_eq!(
+                step.enabled, enabled_before[i],
+                "step {i} enabled flag changed by GenerateRandomSequence"
+            );
+        }
+    }
+
+    #[test]
+    fn test_generate_random_sequence_enabled_flags_preserved_mixed() {
+        let mut state = SequencerState::default();
+        // Set alternating enabled flags.
+        for (i, step) in state.steps.iter_mut().enumerate() {
+            step.enabled = i % 2 == 0;
+        }
+        let enabled_before: [bool; 16] = core::array::from_fn(|i| state.steps[i].enabled);
+        state.apply_command(InputCommand::GenerateRandomSequence);
+        for (i, step) in state.steps.iter().enumerate() {
+            assert_eq!(
+                step.enabled, enabled_before[i],
+                "step {i} enabled flag changed"
+            );
+        }
+    }
+
+    #[test]
+    fn test_generate_random_sequence_notes_in_range_48_84() {
+        let mut state = SequencerState::default();
+        // Run multiple times to increase confidence.
+        for _ in 0..20 {
+            state.apply_command(InputCommand::GenerateRandomSequence);
+            for (i, step) in state.steps.iter().enumerate() {
+                assert!(
+                    step.midi_note >= 48 && step.midi_note <= 84,
+                    "step {i} note {} out of range 48–84 after repeated GenerateRandomSequence",
+                    step.midi_note
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_generate_random_sequence_notes_in_key() {
+        let mut state = SequencerState::default(); // Key::C, Mode::Major
+        for _ in 0..20 {
+            state.apply_command(InputCommand::GenerateRandomSequence);
+            for (i, step) in state.steps.iter().enumerate() {
+                let snapped =
+                    crate::music_theory::snap_to_key(step.midi_note, state.key, state.mode);
+                assert_eq!(
+                    step.midi_note, snapped,
+                    "step {i} note {} not in key C Major after GenerateRandomSequence",
+                    step.midi_note
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_generate_random_sequence_produces_variety() {
+        // Over 10 calls the 16-step sequence should not always be identical.
+        let mut state = SequencerState::default();
+        state.apply_command(InputCommand::GenerateRandomSequence);
+        let first: [u8; 16] = core::array::from_fn(|i| state.steps[i].midi_note);
+        let mut all_same = true;
+        for _ in 0..9 {
+            state.apply_command(InputCommand::GenerateRandomSequence);
+            let current: [u8; 16] = core::array::from_fn(|i| state.steps[i].midi_note);
+            if current != first {
+                all_same = false;
+                break;
+            }
+        }
+        assert!(!all_same, "GenerateRandomSequence produced identical sequences 10 times in a row");
     }
 }
 

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -40,7 +40,7 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 
 use crate::input::{InputCommand, KeyCodeSimple, OverlayMode};
-use crate::input::{overlay_key_to_command, root_key_to_command};
+use crate::input::{overlay_key_to_command, root_key_to_command, shift_action_key_to_command};
 use crate::state::SequencerState;
 use crate::ui_render::render_frame;
 
@@ -105,7 +105,11 @@ fn translate_key(event: KeyEvent, ui: &UiState) -> Option<InputCommand> {
 
     match ui.overlay {
         None => root_key_to_command(simple, shift),
-        Some(_) => overlay_key_to_command(simple),
+        Some(OverlayMode::Shift) => {
+            // Action shortcuts (s/g) take priority; arrow/enter/esc fall through.
+            shift_action_key_to_command(simple).or_else(|| overlay_key_to_command(simple))
+        }
+        Some(OverlayMode::Regular) => overlay_key_to_command(simple),
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `shift_action_key_to_command` to `engine/src/input.rs` — a pure function mapping `'s'`/`'S'` → `SkipModifierToggle` and `'g'`/`'G'` → `GenerateRandomSequence`; all other keys return `None`
- Updates `translate_key` in `engine/src/ui.rs` to try `shift_action_key_to_command` first when the Shift overlay is active, falling through to `overlay_key_to_command` so arrow/Enter/Esc param-navigation is preserved unchanged
- Regular overlay and no-overlay key paths are completely unaffected

## Key Architectural Decisions

- Shift action dispatch is a first-try/fall-through pattern: action keys are checked before navigation keys, meaning no navigation key (`Up`/`Down`/`Left`/`Right`/`Enter`/`Esc`) can accidentally shadow an action
- `shift_action_key_to_command` is a standalone pure function (no state, no side effects) to keep it easily testable and reusable

## Test Coverage

- 8 inline unit tests in `input.rs` cover all four key variants (s/S → SkipModifierToggle, g/G → GenerateRandomSequence), arrow keys returning `None`, Enter/Esc returning `None`, other chars returning `None`, and a sanity check that `overlay_key_to_command` fallthrough still works
- All new public items carry doc comments
- `cargo test -p engine`: 92 unit tests + full integration suite — all pass (0 failures)
- `cargo clippy -p engine`: clean, 0 warnings

## Known Limitations / Follow-up

- `NoteModifierSet` and `VelocityModifierSet` keyboard bindings are not yet wired (out of scope for this stream per task spec — only `s` and `g` were required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)