### PR TITLE
engine: replace overlay InputCommand variants in hid.rs with focus-model equivalents

### DIFF
--- a/engine/src/hid.rs
+++ b/engine/src/hid.rs
@@ -20,12 +20,11 @@
 //   Bytes 2-3  : led_state[15:0]
 //   Bytes 4-63 : reserved
 //
-// Translation note: overlay-aware routing (NoteDelta vs ParamValueDelta for
-// encoders when an overlay is open) is a future improvement. The HID thread
-// reads `state.active_overlay` to determine context; sending NoteDelta
-// unconditionally here is the stub behaviour documented in the task spec.
+// Translation note: HID encoder events always send NoteDelta; param-knob
+// events send PanelParamDelta. Overlay open/close hardware gestures are not
+// in scope for this refactor and are silently dropped.
 
-use crate::input::{InputCommand, OverlayMode};
+use crate::input::InputCommand;
 #[cfg(feature = "hw-io")]
 use crate::state::SequencerState;
 #[cfg(feature = "hw-io")]
@@ -133,36 +132,28 @@ impl OutReport {
 
 /// Translate one `InReport` into a sequence of `InputCommand` values.
 ///
-/// Pure function: no I/O, no locks, no side effects.  The `active_overlay`
-/// argument is the current overlay state (read from shared state by the caller).
+/// Pure function: no I/O, no locks, no side effects.
 ///
 /// Param-button mapping (0-indexed from LSB of the two `param_buttons` bytes):
-/// - Bit 0  → OpenOverlay(Regular) + ParamSelect(0) (Key)
-/// - Bit 1  → ParamSelect(1) (Mode)
-/// - Bit 2  → ParamSelect(2) (Swing)
-/// - Bit 3  → ParamSelect(3) (Step Size)
+/// - Bit 0  → PanelParamSelect(0) (Key)
+/// - Bit 1  → PanelParamSelect(1) (Mode)
+/// - Bit 2  → PanelParamSelect(2) (Swing)
+/// - Bit 3  → PanelParamSelect(3) (Step Size)
 /// - Bits 4–7 → reserved (ignored)
-/// - Bit 8  → loop cycle: active_overlay determines in/out/clear cycling
+/// - Bit 8  → PanelParamSelect(4) + PanelParamDelta(1) (loop cycle)
 /// - Bit 9  → reserved (ignored)
-/// - Bit 10 → pause toggle (ParamValueDelta(1) stub — full state write in run_hid)
+/// - Bit 10 → PanelParamSelect(5) + PanelParamDelta(1) (pause toggle stub)
 /// - Bit 11 → stop/start toggle (handled via direct state write in run_hid)
 ///
-/// Tempo delta and stop/start/pause are handled by `run_hid` with a write
-/// lock; they do NOT appear in the returned Vec.
-pub fn translate_in_report(
-    report: &InReport,
-    active_overlay: Option<OverlayMode>,
-) -> Vec<InputCommand> {
+/// Tempo delta and stop/start/pause direct state mutations are handled by
+/// `run_hid` under a write lock; they do NOT appear in the returned Vec.
+/// Hardware overlay open/close gestures are not in scope and are dropped.
+pub fn translate_in_report(report: &InReport) -> Vec<InputCommand> {
     let mut cmds: Vec<InputCommand> = Vec::new();
 
     // --- Encoder deltas (steps 0–15): note delta per step.
-    // Overlay-aware routing is a future improvement; always send NoteDelta.
     for (i, &delta) in report.encoder_deltas.iter().enumerate() {
         if delta != 0 {
-            // When an overlay is active the encoder controls param value;
-            // without overlay it controls the note for that step.
-            // Future: route to ParamValueDelta when overlay is open.
-            let _ = active_overlay; // suppress unused-variable lint
             cmds.push(InputCommand::StepSelect(i));
             cmds.push(InputCommand::NoteDelta(delta));
         }
@@ -180,35 +171,30 @@ pub fn translate_in_report(
     // --- Param buttons (bits 0–11 across two bytes).
     let param_word = (report.param_buttons[0] as u16) | ((report.param_buttons[1] as u16) << 8);
 
-    // Bits 0–3: overlay + param select.
-    // Bit 0: Key (index 0) — also opens overlay.
-    if param_word & (1 << 0) != 0 {
-        cmds.push(InputCommand::OpenOverlay(OverlayMode::Regular));
-        cmds.push(InputCommand::ParamSelect(0));
-    }
-    // Bits 1–3: Mode, Swing, Step Size (indices 1–3).
-    for idx in 1u8..=3 {
+    // Bits 0–3: param select (Key, Mode, Swing, Step Size at indices 0–3).
+    // Hardware overlay open/close is dropped — focus switching from hardware
+    // is not in scope for this refactor.
+    for idx in 0u8..=3 {
         if param_word & (1 << idx) != 0 {
-            cmds.push(InputCommand::ParamSelect(idx));
+            cmds.push(InputCommand::PanelParamSelect(idx));
         }
     }
 
     // Bit 8: loop in/out/clear cycling.
-    // Loop cycle is a 3-state machine: set loop_in → set loop_out → clear.
-    // The HID thread advances the cycle by emitting ParamSelect(4) (loop param)
-    // + ParamValueDelta(1). Full loop-state machine lives in state.rs (future).
+    // The HID thread advances the cycle by selecting param index 4 (loop param)
+    // and sending a positive delta. Full loop-state machine lives in state.rs (future).
     if param_word & (1 << 8) != 0 {
-        cmds.push(InputCommand::ParamSelect(4));
-        cmds.push(InputCommand::ParamValueDelta(1));
+        cmds.push(InputCommand::PanelParamSelect(4));
+        cmds.push(InputCommand::PanelParamDelta(1));
     }
 
     // Bit 9: reserved — ignored.
 
-    // Bit 10: pause toggle — emit ParamValueDelta on param index 5 (pause).
+    // Bit 10: pause toggle — select param index 5 (pause) and send a delta.
     // Direct state mutation (paused flag) is performed by run_hid under write lock.
     if param_word & (1 << 10) != 0 {
-        cmds.push(InputCommand::ParamSelect(5));
-        cmds.push(InputCommand::ParamValueDelta(1));
+        cmds.push(InputCommand::PanelParamSelect(5));
+        cmds.push(InputCommand::PanelParamDelta(1));
     }
 
     // Bit 11: stop/start — direct state mutation in run_hid; no InputCommand emitted.
@@ -216,7 +202,7 @@ pub fn translate_in_report(
 
     // --- Param knob delta.
     if report.param_knob_delta != 0 {
-        cmds.push(InputCommand::ParamValueDelta(report.param_knob_delta));
+        cmds.push(InputCommand::PanelParamDelta(report.param_knob_delta));
     }
 
     cmds
@@ -413,14 +399,8 @@ pub fn run_hid(
             }
         }
 
-        // Read active_overlay for translation context.
-        let active_overlay = state
-            .read()
-            .expect("hid: state read lock poisoned")
-            .active_overlay;
-
         // --- Translate to InputCommand and send. ---
-        let cmds = translate_in_report(&report, active_overlay);
+        let cmds = translate_in_report(&report);
         for cmd in cmds {
             if cmd_tx.send(cmd).is_err() {
                 // Receiver dropped — engine is shutting down.

--- a/engine/tests/hid.rs
+++ b/engine/tests/hid.rs
@@ -818,3 +818,127 @@ fn hid_vid_pid_constants_still_exported_after_open_device_removal() {
         "HID_PID must still be 0x000A after open_device removal"
     );
 }
+
+// -----------------------------------------------------------------------
+// translate_in_report — coverage gaps from Task 3.2 QA review.
+// -----------------------------------------------------------------------
+
+/// Negative param_knob_delta must produce PanelParamDelta with the correct
+/// signed value. The existing positive-knob test only exercises the positive
+/// branch; this confirms the i8 sign is preserved end-to-end.
+#[test]
+fn translate_param_knob_delta_negative_emits_correct_signed_delta() {
+    let mut buf = [0u8; 64];
+    buf[26] = (-5i8) as u8; // param_knob_delta = -5
+    let report = InReport::from_bytes(&buf);
+    let cmds = translate_in_report(&report);
+
+    assert_eq!(
+        cmds.len(),
+        1,
+        "expected exactly 1 command for param_knob_delta=-5, got {cmds:?}"
+    );
+    assert!(
+        matches!(cmds[0], InputCommand::PanelParamDelta(-5)),
+        "cmds[0] should be PanelParamDelta(-5); got {:?}",
+        cmds[0]
+    );
+}
+
+/// Regression guard: no command produced by translate_in_report must be one
+/// of the old overlay variants (OpenOverlay, CloseOverlay, ParamSelect,
+/// ParamSelectDelta, ParamValueDelta). These variants still exist in the enum
+/// (used by the keyboard path) so a future edit could accidentally reintroduce
+/// them on the HID path. Exercise a report with all param-button bits that
+/// previously sent overlay commands (bits 0–3, bit 8, bit 10) and assert the
+/// output contains only PanelParamSelect / PanelParamDelta.
+#[test]
+fn translate_no_command_is_old_overlay_variant() {
+    let mut buf = [0u8; 64];
+    // Bits 0–3 (PanelParamSelect 0–3), bit 8 (loop cycle), bit 10 (pause).
+    buf[7] = 0b0000_1111; // param_buttons[0]: bits 0–3
+    buf[8] = 0b0000_0101; // param_buttons[1]: bit 0 (overall bit 8) + bit 2 (bit 10)
+    let report = InReport::from_bytes(&buf);
+    let cmds = translate_in_report(&report);
+
+    // 4 × PanelParamSelect(0..=3) + 2 × (PanelParamSelect + PanelParamDelta) = 8 total.
+    assert_eq!(
+        cmds.len(),
+        8,
+        "expected 8 commands for bits 0-3 + bit8 + bit10, got {cmds:?}"
+    );
+
+    for (i, cmd) in cmds.iter().enumerate() {
+        let is_old_overlay = matches!(
+            cmd,
+            InputCommand::OpenOverlay(_)
+                | InputCommand::CloseOverlay
+                | InputCommand::ParamSelect(_)
+                | InputCommand::ParamSelectDelta(_)
+                | InputCommand::ParamValueDelta(_)
+        );
+        assert!(
+            !is_old_overlay,
+            "cmds[{i}] is a deprecated overlay variant that must not appear in HID output: {cmd:?}"
+        );
+    }
+}
+
+/// Full mixed report: all four HID input types active simultaneously.
+/// Encoder 0 has a positive delta, step button 2 is pressed, param button 1
+/// (Mode) is pressed, and param_knob_delta is negative. The expected command
+/// sequence covers all categories in emission order (encoders → steps → param
+/// buttons → param knob).
+#[test]
+fn translate_full_mixed_report_all_input_types() {
+    let mut buf = [0u8; 64];
+    buf[9] = 1i8 as u8;       // encoder_deltas[0] = +1
+    buf[3] = 0b0000_0100;     // step_buttons low: bit 2 → step 2
+    buf[7] = 0b0000_0010;     // param_buttons[0]: bit 1 → PanelParamSelect(1)
+    buf[26] = (-3i8) as u8;   // param_knob_delta = -3
+    let report = InReport::from_bytes(&buf);
+    let cmds = translate_in_report(&report);
+
+    // Expected sequence (emission order):
+    //   0: StepSelect(0)      — encoder 0 focus
+    //   1: NoteDelta(1)       — encoder 0 delta
+    //   2: StepSelect(2)      — step button 2 press
+    //   3: ToggleStep         — step button 2 press
+    //   4: PanelParamSelect(1)— param button bit 1
+    //   5: PanelParamDelta(-3)— param knob
+    assert_eq!(
+        cmds.len(),
+        6,
+        "expected 6 commands for mixed report, got {cmds:?}"
+    );
+    assert!(
+        matches!(cmds[0], InputCommand::StepSelect(0)),
+        "cmds[0] should be StepSelect(0); got {:?}",
+        cmds[0]
+    );
+    assert!(
+        matches!(cmds[1], InputCommand::NoteDelta(1)),
+        "cmds[1] should be NoteDelta(1); got {:?}",
+        cmds[1]
+    );
+    assert!(
+        matches!(cmds[2], InputCommand::StepSelect(2)),
+        "cmds[2] should be StepSelect(2); got {:?}",
+        cmds[2]
+    );
+    assert!(
+        matches!(cmds[3], InputCommand::ToggleStep),
+        "cmds[3] should be ToggleStep; got {:?}",
+        cmds[3]
+    );
+    assert!(
+        matches!(cmds[4], InputCommand::PanelParamSelect(1)),
+        "cmds[4] should be PanelParamSelect(1); got {:?}",
+        cmds[4]
+    );
+    assert!(
+        matches!(cmds[5], InputCommand::PanelParamDelta(-3)),
+        "cmds[5] should be PanelParamDelta(-3); got {:?}",
+        cmds[5]
+    );
+}

--- a/engine/tests/hid.rs
+++ b/engine/tests/hid.rs
@@ -1,5 +1,5 @@
 use engine::hid::{compute_led_bytes, translate_in_report, InReport, OutReport, HID_PID, HID_VID};
-use engine::input::{InputCommand, OverlayMode};
+use engine::input::InputCommand;
 
 /// Build a raw 64-byte buffer with distinct non-zero values in every field
 /// so that a round-trip test can verify no field is silently aliased or
@@ -434,7 +434,7 @@ fn translate_encoder_delta_step0_emits_step_select_and_note_delta() {
     let mut buf = [0u8; 64];
     buf[9] = 3i8 as u8; // encoder_deltas[0] = +3
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
 
     // Should see StepSelect(0) then NoteDelta(3).
     let mut iter = cmds.iter();
@@ -447,7 +447,7 @@ fn translate_encoder_delta_negative_emits_correct_delta() {
     let mut buf = [0u8; 64];
     buf[9 + 5] = (-2i8) as u8; // encoder_deltas[5] = -2
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
 
     assert!(matches!(cmds[0], InputCommand::StepSelect(5)));
     assert!(matches!(cmds[1], InputCommand::NoteDelta(-2)));
@@ -456,7 +456,7 @@ fn translate_encoder_delta_negative_emits_correct_delta() {
 #[test]
 fn translate_zero_encoder_deltas_produces_no_encoder_commands() {
     let report = zero_report();
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
     // With all-zero input, no commands should be produced.
     assert!(
         cmds.is_empty(),
@@ -469,7 +469,7 @@ fn translate_step_button_bit3_emits_step_select_and_toggle() {
     let mut buf = [0u8; 64];
     buf[3] = 0b0000_1000; // step_buttons low: bit 3 set → step 3
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
 
     assert_eq!(cmds.len(), 2, "expected StepSelect + ToggleStep");
     assert!(matches!(cmds[0], InputCommand::StepSelect(3)));
@@ -482,7 +482,7 @@ fn translate_step_button_high_byte_bit_emits_correct_step_index() {
     let mut buf = [0u8; 64];
     buf[4] = 0b0000_0010; // bit 9 overall
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
 
     assert_eq!(cmds.len(), 2);
     assert!(matches!(cmds[0], InputCommand::StepSelect(9)));
@@ -490,29 +490,26 @@ fn translate_step_button_high_byte_bit_emits_correct_step_index() {
 }
 
 #[test]
-fn translate_param_button_bit0_opens_overlay_and_selects_param0() {
+fn translate_param_button_bit0_selects_panel_param0() {
+    // Hardware overlay open is dropped; bit 0 now emits only PanelParamSelect(0).
     let mut buf = [0u8; 64];
     buf[7] = 0b0000_0001; // param_buttons[0] bit 0 = Key
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
 
-    assert_eq!(cmds.len(), 2);
-    assert!(matches!(
-        cmds[0],
-        InputCommand::OpenOverlay(OverlayMode::Regular)
-    ));
-    assert!(matches!(cmds[1], InputCommand::ParamSelect(0)));
+    assert_eq!(cmds.len(), 1, "expected only PanelParamSelect(0), got {cmds:?}");
+    assert!(matches!(cmds[0], InputCommand::PanelParamSelect(0)));
 }
 
 #[test]
-fn translate_param_button_bit1_selects_param1() {
+fn translate_param_button_bit1_selects_panel_param1() {
     let mut buf = [0u8; 64];
     buf[7] = 0b0000_0010; // bit 1 = Mode
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
 
     assert_eq!(cmds.len(), 1);
-    assert!(matches!(cmds[0], InputCommand::ParamSelect(1)));
+    assert!(matches!(cmds[0], InputCommand::PanelParamSelect(1)));
 }
 
 #[test]
@@ -521,11 +518,11 @@ fn translate_param_button_bit8_emits_loop_param_cycle() {
     let mut buf = [0u8; 64];
     buf[8] = 0b0000_0001; // param_buttons high byte bit 0 = overall bit 8
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
 
     assert_eq!(cmds.len(), 2);
-    assert!(matches!(cmds[0], InputCommand::ParamSelect(4)));
-    assert!(matches!(cmds[1], InputCommand::ParamValueDelta(1)));
+    assert!(matches!(cmds[0], InputCommand::PanelParamSelect(4)));
+    assert!(matches!(cmds[1], InputCommand::PanelParamDelta(1)));
 }
 
 #[test]
@@ -534,11 +531,11 @@ fn translate_param_button_bit10_emits_pause_param_cycle() {
     let mut buf = [0u8; 64];
     buf[8] = 0b0000_0100;
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
 
     assert_eq!(cmds.len(), 2);
-    assert!(matches!(cmds[0], InputCommand::ParamSelect(5)));
-    assert!(matches!(cmds[1], InputCommand::ParamValueDelta(1)));
+    assert!(matches!(cmds[0], InputCommand::PanelParamSelect(5)));
+    assert!(matches!(cmds[1], InputCommand::PanelParamDelta(1)));
 }
 
 #[test]
@@ -547,7 +544,7 @@ fn translate_param_button_bit11_emits_no_input_command() {
     let mut buf = [0u8; 64];
     buf[8] = 0b0000_1000;
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
     // bit11 alone should produce no InputCommand entries.
     assert!(
         cmds.is_empty(),
@@ -556,14 +553,14 @@ fn translate_param_button_bit11_emits_no_input_command() {
 }
 
 #[test]
-fn translate_param_knob_delta_emits_param_value_delta() {
+fn translate_param_knob_delta_emits_panel_param_delta() {
     let mut buf = [0u8; 64];
     buf[26] = 7i8 as u8; // param_knob_delta = +7
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
 
     assert_eq!(cmds.len(), 1);
-    assert!(matches!(cmds[0], InputCommand::ParamValueDelta(7)));
+    assert!(matches!(cmds[0], InputCommand::PanelParamDelta(7)));
 }
 
 #[test]
@@ -574,15 +571,15 @@ fn translate_synthetic_full_report_encoder_step_param() {
     buf[3] = 0b0000_1000; // step_buttons bit 3 = step 3
     buf[7] = 0b0000_0010; // param_buttons bit 1 = Mode
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
 
-    // Expected: StepSelect(0), NoteDelta(1), StepSelect(3), ToggleStep, ParamSelect(1).
+    // Expected: StepSelect(0), NoteDelta(1), StepSelect(3), ToggleStep, PanelParamSelect(1).
     assert_eq!(cmds.len(), 5, "expected 5 commands, got {cmds:?}");
     assert!(matches!(cmds[0], InputCommand::StepSelect(0)));
     assert!(matches!(cmds[1], InputCommand::NoteDelta(1)));
     assert!(matches!(cmds[2], InputCommand::StepSelect(3)));
     assert!(matches!(cmds[3], InputCommand::ToggleStep));
-    assert!(matches!(cmds[4], InputCommand::ParamSelect(1)));
+    assert!(matches!(cmds[4], InputCommand::PanelParamSelect(1)));
 }
 
 #[test]
@@ -594,7 +591,7 @@ fn translate_multiple_simultaneous_encoder_deltas_all_produce_commands() {
     buf[9 + 7] = (-3i8) as u8; // encoder_deltas[7]  = -3
     buf[9 + 15] = 1i8 as u8; // encoder_deltas[15] = +1
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
 
     // Expect exactly 6 commands: (StepSelect(0), NoteDelta(5)),
     // (StepSelect(7), NoteDelta(-3)), (StepSelect(15), NoteDelta(1)).
@@ -704,7 +701,7 @@ fn compute_led_bytes_only_step7_sets_lo_bit7() {
 fn translate_all_zero_report_emits_no_commands() {
     // An InReport where every field is zero must produce an empty command list.
     let report = InReport::from_bytes(&[0u8; 64]);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
     assert!(
         cmds.is_empty(),
         "all-zero InReport must emit no InputCommands, got {cmds:?}"
@@ -719,7 +716,7 @@ fn translate_all_16_step_buttons_set_emits_32_commands() {
     buf[3] = 0xFF; // step_buttons low byte: steps 0–7
     buf[4] = 0xFF; // step_buttons high byte: steps 8–15
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
 
     assert_eq!(
         cmds.len(),
@@ -748,54 +745,52 @@ fn translate_param_buttons_bits_0_1_2_3_all_set_emits_correct_commands() {
     let mut buf = [0u8; 64];
     buf[7] = 0b0000_1111; // bits 0, 1, 2, 3 set
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, None);
+    let cmds = translate_in_report(&report);
 
-    // Expected order: OpenOverlay(Regular), ParamSelect(0), ParamSelect(1),
-    // ParamSelect(2), ParamSelect(3) — 5 total.
+    // Expected order: PanelParamSelect(0), PanelParamSelect(1),
+    // PanelParamSelect(2), PanelParamSelect(3) — 4 total.
+    // Hardware overlay open/close is dropped in this refactor.
     assert_eq!(
         cmds.len(),
-        5,
-        "expected 5 commands for bits 0–3, got {cmds:?}"
+        4,
+        "expected 4 commands for bits 0–3, got {cmds:?}"
     );
     assert!(
-        matches!(cmds[0], InputCommand::OpenOverlay(OverlayMode::Regular)),
-        "cmds[0] should be OpenOverlay(Regular)"
+        matches!(cmds[0], InputCommand::PanelParamSelect(0)),
+        "cmds[0] should be PanelParamSelect(0)"
     );
     assert!(
-        matches!(cmds[1], InputCommand::ParamSelect(0)),
-        "cmds[1] should be ParamSelect(0)"
+        matches!(cmds[1], InputCommand::PanelParamSelect(1)),
+        "cmds[1] should be PanelParamSelect(1)"
     );
     assert!(
-        matches!(cmds[2], InputCommand::ParamSelect(1)),
-        "cmds[2] should be ParamSelect(1)"
+        matches!(cmds[2], InputCommand::PanelParamSelect(2)),
+        "cmds[2] should be PanelParamSelect(2)"
     );
     assert!(
-        matches!(cmds[3], InputCommand::ParamSelect(2)),
-        "cmds[3] should be ParamSelect(2)"
-    );
-    assert!(
-        matches!(cmds[4], InputCommand::ParamSelect(3)),
-        "cmds[4] should be ParamSelect(3)"
+        matches!(cmds[3], InputCommand::PanelParamSelect(3)),
+        "cmds[3] should be PanelParamSelect(3)"
     );
 }
 
 #[test]
-fn translate_encoder_delta_with_active_overlay_emits_note_delta_not_param_value_delta() {
-    // Documents current behaviour: overlay-aware routing is deferred.
+fn translate_encoder_delta_emits_note_delta() {
+    // Encoder deltas always produce StepSelect + NoteDelta regardless of context.
+    // Panel-focus-aware routing is handled by the UI layer, not the HID thread.
     let mut buf = [0u8; 64];
     buf[9 + 3] = 2i8 as u8; // encoder_deltas[3] = +2
     let report = InReport::from_bytes(&buf);
-    let cmds = translate_in_report(&report, Some(OverlayMode::Regular));
+    let cmds = translate_in_report(&report);
 
     assert_eq!(cmds.len(), 2, "expected exactly 2 commands, got {cmds:?}");
     assert!(
         matches!(cmds[0], InputCommand::StepSelect(3)),
-        "cmds[0] should be StepSelect(3) regardless of overlay; got {:?}",
+        "cmds[0] should be StepSelect(3); got {:?}",
         cmds[0]
     );
     assert!(
         matches!(cmds[1], InputCommand::NoteDelta(2)),
-        "cmds[1] should be NoteDelta(2) — overlay-aware routing is deferred; got {:?}",
+        "cmds[1] should be NoteDelta(2); got {:?}",
         cmds[1]
     );
 }

--- a/engine/tests/input.rs
+++ b/engine/tests/input.rs
@@ -1,5 +1,5 @@
 use engine::input::{
-    overlay_key_to_command, root_key_to_command, InputCommand, KeyCodeSimple, OverlayMode,
+    overlay_key_to_command, root_key_to_command, FocusPanel, InputCommand, KeyCodeSimple,
 };
 
 // --- root_key_to_command ---
@@ -53,20 +53,20 @@ fn root_enter_is_confirm() {
 }
 
 #[test]
-fn root_f1_opens_regular_overlay() {
+fn root_f1_sets_focus_sequencer() {
     let cmd = root_key_to_command(KeyCodeSimple::F1, false);
     assert!(matches!(
         cmd,
-        Some(InputCommand::OpenOverlay(OverlayMode::Regular))
+        Some(InputCommand::SetFocus(FocusPanel::Sequencer))
     ));
 }
 
 #[test]
-fn root_f2_opens_shift_overlay() {
+fn root_f2_sets_focus_seq_params() {
     let cmd = root_key_to_command(KeyCodeSimple::F2, false);
     assert!(matches!(
         cmd,
-        Some(InputCommand::OpenOverlay(OverlayMode::Shift))
+        Some(InputCommand::SetFocus(FocusPanel::SeqParams))
     ));
 }
 


### PR DESCRIPTION
## Summary

- Removed all references to deprecated `InputCommand` overlay variants (`OpenOverlay`, `CloseOverlay`, `ParamSelect`, `ParamSelectDelta`, `ParamValueDelta`) from `engine/src/hid.rs`
- Replaced param-select sends with `PanelParamSelect(u8)` and param-delta sends with `PanelParamDelta(i8)` — the new focus-model equivalents
- Simplified `translate_in_report` signature: removed the now-unused `active_overlay: Option<OverlayMode>` parameter (was already suppressed with `let _ =`); function is now a pure `(report: &InReport) -> Vec<InputCommand>`
- Removed `OverlayMode` import from `hid.rs` and `engine/tests/input.rs`; updated two stale input tests (`root_f1_opens_regular_overlay`, `root_f2_opens_shift_overlay`) to assert `SetFocus(FocusPanel::*)` per the new model

## Key Architectural Decisions

- Hardware overlay open/close gestures are silently dropped (no HID-driven panel focus change in this refactor scope) — aligns with Option A from the architecture plan
- `translate_in_report` is now a pure function; callers in `run_hid` updated to pass no second argument
- All other HID encoder/button logic (step select, note delta, velocity, play/stop) is untouched

## Test Coverage

- `cargo test -p engine` passes: 74 unit + 46 hid integration + 19 input integration + additional suites — 0 failures
- Three new regression tests added to `engine/tests/hid.rs`:
  - `translate_param_knob_delta_negative_emits_correct_signed_delta` — verifies negative i8 sign preservation through `PanelParamDelta`
  - `translate_no_command_is_old_overlay_variant` — regression guard asserting no command from param-button bits 0–3/8/10 is a removed variant
  - `translate_full_mixed_report_all_input_types` — end-to-end ordering test with all four HID input types active simultaneously
- All tests are unit/integration tests with no external dependencies

## Known Limitations / Follow-up

- Hardware overlay open/close from HID is not wired in this refactor; a future task may introduce explicit `SetFocus` commands from HID encoder press if required
- Closes #78 (partial — `hid.rs` compatibility leg of the ui-refactor feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)