### PR TITLE
chore(workflow): post-cli-commands housekeeping

### DIFF
--- a/.workflow/BACKLOG.md
+++ b/.workflow/BACKLOG.md
@@ -1,5 +1,13 @@
 # BACKLOG
 
+## Test hygiene: add `parse_note_name` test for `s` sharp suffix (BUG-019)
+- **File:** `engine/src/music_theory.rs` test module.
+- The `parse_note_name` implementation matches `b'#' | b's'` for sharps but
+  the test suite only exercises `#` (e.g. `F#3`). The `s` variant (e.g. `Fs3`)
+  has zero coverage — removing `| b's'` from the match arm passes tests.
+- **Fix:** add `assert_eq!(parse_note_name("Fs3"), Some(54));` to the existing
+  `#[cfg(test)] mod tests` block.
+
 ## Test hygiene: fix pre-existing `clippy --all-targets` errors in engine/tests
 - 17 errors across `engine/tests/{clock,hid,main_wiring,ui}.rs`.
 - None block the lib build (`cargo clippy -p engine -- -D warnings` is clean);

--- a/.workflow/DONE.md
+++ b/.workflow/DONE.md
@@ -1,5 +1,14 @@
 # DONE
 
+## cli-commands (issue #99) — merged PR #110 — 2026-05-13
+8 new CLI commands (`rand all/velo/notes`, `note set`, `port list`, `clear`/`ok`,
+`help`) wired through ui → state → midi-out. `parse_note_name` added as the
+inverse of `note_name`. MIDI `ListPorts` enumeration via control channel with
+sentinel-based UI rendering. Six Copilot review nits resolved in PR #111
+(strict 1–16 step indexing, trailing-token rejection, ports-sentinel doc
+cleanup, indexed-fallback port names, `ok` alias in HELP_ENTRIES). 640
+engine tests passing.
+
 ## ui-refactor (issue #78) — merged PR #93 — 2026-05-03
 4-panel cyberpunk TUI with focus model, CLI panel, runtime MIDI port/channel
 switching, HID compatibility, and clock NoteOff race fix (PR #93 + hotfixes).


### PR DESCRIPTION
## Summary

- Record cli-commands feature as DONE (PRs #110, #111 — 2026-05-13).
- Add BUG-019 to BACKLOG: `parse_note_name("Fs3")` has no test coverage despite the `b'#' | b's'` match arm.

Workflow-only change. No production code touched.

## Test plan

- [x] No code changes — nothing to test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)