### PR TITLE
feat(engine): song mode — pattern save/load and song sequencing

### DIFF
--- a/.workflow/BACKLOG.md
+++ b/.workflow/BACKLOG.md
@@ -1,11 +1,4 @@
 # BACKLOG
-- plan for "song mode".
-  1. pattern saving/loading. 
-  2. songs = pattern chaining.
-  3. song mode - like a 8bit tracker?
-  4. songs, save/load. FileFormat?
-  5. switch between pattern/song mode? f9/f10?
-
 
 ## Test hygiene: add `parse_note_name` test for `s` sharp suffix (BUG-019)
 - **File:** `engine/src/music_theory.rs` test module.

--- a/.workflow/TODO.md
+++ b/.workflow/TODO.md
@@ -1,3 +1,12 @@
 # TODO
 
-(empty — see BACKLOG.md for upcoming work)
+## song-mode
+Plan: `.workflow/plans/song-mode.md`
+Tasks:
+- `.workflow/tasks/song-mode-01-cargo-deps.md` (group 1)
+- `.workflow/tasks/song-mode-02-pattern-module.md` (group 2)
+- `.workflow/tasks/song-mode-03-state-and-input.md` (group 3)
+- `.workflow/tasks/song-mode-04-ui-state-and-cli.md` (group 4, parallel)
+- `.workflow/tasks/song-mode-05-ui-render.md` (group 4, parallel)
+- `.workflow/tasks/song-mode-06-main-wiring.md` (group 5)
+- `.workflow/tasks/song-mode-07-integration-tests.md` (group 6)

--- a/.workflow/logs/session-2026-05-16T00-00-00.md
+++ b/.workflow/logs/session-2026-05-16T00-00-00.md
@@ -1,0 +1,24 @@
+# Session Log — 2026-05-16T00-00-00
+
+## [00:00:00] Session Start — coordinator orient
+**TODO count:** 0
+**In-progress count:** 0
+**Bug count:** 0 open (1 closed: BUG-018)
+**Open PR count:** 0
+**Backlog items:** 3 (song-mode epic, BUG-019 parse_note_name test, clippy --all-targets hygiene)
+**Decided focus:** song mode epic (TOML files, unbounded Vec, vertical slot TUI, F9/F10 switching)
+
+## [00:05:00] Spawned architect — song-mode
+**Feature:** song-mode
+**Decisions passed:** TOML format, unbounded Vec, vertical slot list TUI, F9/F10 switching
+**Output:** .workflow/plans/song-mode.md
+
+## [00:15:00] architect complete — song-mode
+**Key output:** .workflow/plans/song-mode.md (787 lines)
+**Key decisions:** TickResult enum, Arc<RwLock<Song>> ownership, F1 zone replaced, ~/.config file paths, serde+toml deps
+**Next action:** spawn manager for task breakdown
+
+## [00:15:01] Spawned manager — song-mode
+**Feature:** song-mode
+**Plan:** .workflow/plans/song-mode.md
+**User directive:** run full pipeline end-to-end, no gate confirmations needed

--- a/.workflow/plans/song-mode.md
+++ b/.workflow/plans/song-mode.md
@@ -1,0 +1,787 @@
+# Plan: Song Mode
+
+## Architecture Overview
+
+Song mode chains saved patterns into a linear playlist. The engine continues to
+use a single `SequencerState` for live playback; song mode provides a layer
+above it that swaps the active pattern when the playhead wraps. Patterns are
+stored on disk as TOML files; a song is a separate TOML file that references
+them by filename.
+
+### Key decisions
+
+1. **Pattern files live in `~/.config/midi-man-mk3/patterns/`**; song files in
+   `~/.config/midi-man-mk3/songs/`. The directory is created on first save.
+   Assumption: the operator will not run the engine as root. Flag for review if
+   XDG_CONFIG_HOME must be respected on all target platforms.
+
+2. **Pattern file extension:** `.pat.toml`. Song file extension: `.song.toml`.
+   These are intentionally human-readable so users can hand-edit them.
+
+3. **Song mode does not stop the clock.** When `PlayMode` is `Song`, the clock
+   thread keeps ticking; the command processor detects a pattern boundary and
+   calls a new method `SequencerState::load_pattern_slot(slot: usize)` which
+   swaps steps/key/mode in place. No thread restart is needed.
+
+4. **Song-mode UI replaces the F1 · SEQ panel**, not a new zone. In pattern
+   mode F1 shows the 16-step grid. In song mode F1 shows the vertical slot
+   list. F9/F10 toggle the mode; the label on the F1 zone border changes
+   accordingly. This avoids adding a new layout zone (which would break the
+   existing 7-zone height constraints).
+
+5. **Pattern data serialized includes every user-visible field** in
+   `SequencerState` that describes the pattern itself: steps, key, mode,
+   step_size, swing, loop_in, loop_out, loop_active, tempo_bpm, midi_channel,
+   scale_quant, note_modifier, velocity_modifier, skip_modifier. Fields that
+   are runtime-only (playhead, playing, paused, rng_seed, rand_seed,
+   midi_device_name, pending_edit, active_overlay, selected_step,
+   selected_param, selected_rand_param) are excluded from serialization.
+   The randomness params (tempo_rand, tempo_roll_point, etc.) are included
+   because they shape the sound of the pattern. Flag for operator review:
+   should per-step randomness params be per-pattern or global?
+
+6. **No `toml` crate is currently in the workspace.** `serde` 1.0.228 is
+   transitively present (via ratatui) but not a direct dependency and does not
+   have `derive` features enabled. Both `serde` (with `derive`) and `toml` must
+   be added to `engine/Cargo.toml`.
+
+7. **Song state lives in `UiState`**, not `SequencerState`. The song slot list
+   (`Vec<PatternSlot>`) and cursor are UI concerns. The sequencer only cares
+   about: "am I in song mode?" (a `PlayMode` flag in state) and "which slot am
+   I on?" (a `usize` in state). The pattern data itself is loaded into
+   `SequencerState` on slot transitions.
+
+---
+
+## Data Model
+
+### `StepData` — serializable (no change to struct, derive added)
+
+```
+engine/src/state.rs  — StepData
+  enabled: bool
+  midi_note: u8
+  velocity: u8
+```
+
+### `PatternData` — new serializable struct (separate from runtime `SequencerState`)
+
+New file: `engine/src/pattern.rs`
+
+```rust
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct StepDataSerial {
+    pub enabled: bool,
+    pub midi_note: u8,
+    pub velocity: u8,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PatternData {
+    pub name: String,            // user-visible label, e.g. "verse-A"
+    pub steps: Vec<StepDataSerial>,  // exactly 16 elements
+    pub key: String,             // "C", "C#", "D" … serialized as string
+    pub mode: String,            // "Major", "NaturalMinor" … serialized as string
+    pub tempo_bpm: u16,
+    pub swing: i8,
+    pub step_size: String,       // "1/16", "1/8" …
+    pub loop_in: u8,
+    pub loop_out: u8,
+    pub loop_active: bool,
+    pub midi_channel: u8,        // 0-indexed
+    pub scale_quant: bool,
+    pub note_modifier: i8,
+    pub velocity_modifier: i8,
+    pub skip_modifier: bool,
+    pub tempo_rand: u8,
+    pub tempo_roll_point: String,
+    pub tempo_variance_max: u8,
+    pub tempo_rand_type: String,
+    pub step_rand: u8,
+    pub note_rand: u8,
+}
+```
+
+String-encoded enums are chosen over integer indices to keep TOML files
+human-readable and stable against future reordering.
+
+**TOML schema example:**
+
+```toml
+name = "verse-A"
+tempo_bpm = 120
+swing = 0
+step_size = "1/16"
+key = "C"
+mode = "Major"
+loop_in = 0
+loop_out = 15
+loop_active = false
+midi_channel = 0
+scale_quant = false
+note_modifier = 0
+velocity_modifier = 0
+skip_modifier = false
+tempo_rand = 0
+tempo_roll_point = "Off"
+tempo_variance_max = 10
+tempo_rand_type = "Random"
+step_rand = 0
+note_rand = 0
+
+[[steps]]
+enabled = true
+midi_note = 60
+velocity = 100
+
+[[steps]]
+enabled = false
+midi_note = 60
+velocity = 100
+# … 14 more step entries
+```
+
+### `PatternRef` and `Song`
+
+Also in `engine/src/pattern.rs`:
+
+```rust
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PatternRef {
+    pub filename: String,   // just the filename, not a full path: "verse-A.pat.toml"
+    pub repeats: u8,        // 1 = play once, 2 = play twice, etc.  Default: 1.
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Song {
+    pub name: String,
+    pub slots: Vec<PatternRef>,  // unbounded
+}
+```
+
+**TOML schema example:**
+
+```toml
+name = "my-song"
+
+[[slots]]
+filename = "verse-A.pat.toml"
+repeats = 2
+
+[[slots]]
+filename = "chorus.pat.toml"
+repeats = 1
+```
+
+### File I/O helpers (in `engine/src/pattern.rs`)
+
+```rust
+pub fn pattern_dir() -> PathBuf
+pub fn song_dir() -> PathBuf
+
+pub fn save_pattern(data: &PatternData, filename: &str) -> Result<(), String>
+pub fn load_pattern(filename: &str) -> Result<PatternData, String>
+
+pub fn save_song(song: &Song, filename: &str) -> Result<(), String>
+pub fn load_song(filename: &str) -> Result<Song, String>
+
+pub fn pattern_from_state(state: &SequencerState, name: &str) -> PatternData
+pub fn apply_pattern_to_state(data: &PatternData, state: &mut SequencerState) -> Result<(), String>
+```
+
+`apply_pattern_to_state` deserializes string enum fields (key, mode, etc.) back
+to their enum variants, returning `Err` with a human-readable message if any
+string is unrecognized.
+
+---
+
+## State Machine Changes
+
+### `PlayMode` enum (new, in `engine/src/state.rs`)
+
+```rust
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum PlayMode {
+    #[default]
+    Pattern,
+    Song,
+}
+```
+
+### New fields on `SequencerState`
+
+```rust
+pub play_mode: PlayMode,
+pub song_slot_index: usize,  // current slot position in the song
+pub song_slot_repeat: u8,    // how many times the current slot has been played
+```
+
+### `SequencerState::tick()` change
+
+When `play_mode == PlayMode::Song`, after `playhead` wraps past `loop_out`
+(or past step 15 when loop is off), instead of resetting `playhead` to
+`loop_in`/0, the method emits a sentinel: it sets a new
+`pub song_advance_pending: bool` flag on state and resets the playhead. The
+command processor (or a new song-advance thread hook — see trade-offs) polls
+this flag.
+
+**Simpler alternative chosen:** `tick()` returns a new `TickResult` enum
+instead of `Option<MidiEvent>`:
+
+```rust
+pub enum TickResult {
+    Idle,
+    Note(MidiEvent),
+    PatternEnd,          // song mode only: wrap completed, advance to next slot
+}
+```
+
+The clock thread handles `TickResult::PatternEnd` by sending a new
+`InputCommand::SongAdvance` on `cmd_tx`. The command processor applies it
+under the write lock: increments `song_slot_repeat`; if repeats are exhausted,
+increments `song_slot_index` and calls `load_pattern_slot` which reads the
+next pattern file from disk and applies it to state. This keeps disk I/O off
+the hot clock path (I/O happens in the command-processor thread, not the
+clock thread).
+
+Assumption: disk latency for a small TOML file on a local filesystem is
+negligible (<1 ms) and does not audibly disrupt playback. Flag for operator
+review if this causes glitches in practice; the fallback is pre-loading all
+patterns into memory when a song is loaded.
+
+### New `InputCommand` variants
+
+```rust
+// Toggle between pattern and song mode (F9/F10).
+SwitchToPatternMode,
+SwitchToSongMode,
+
+// Advance the song to the next slot (sent by clock on PatternEnd).
+SongAdvance,
+
+// Song slot list cursor navigation (sent by UI in song mode).
+SongSlotCursorUp,
+SongSlotCursorDown,
+SongSlotInsert(String),   // filename to insert at cursor
+SongSlotDelete,            // delete slot at cursor
+SongSlotMoveUp,            // swap cursor slot with one above
+SongSlotMoveDown,          // swap cursor slot with one below
+```
+
+### `apply_command` additions (in `SequencerState`)
+
+```
+SwitchToPatternMode  → state.play_mode = PlayMode::Pattern
+SwitchToSongMode     → state.play_mode = PlayMode::Song; state.song_slot_index = 0; state.song_slot_repeat = 0
+SongAdvance          → (handled by command processor which has access to the Song struct, not in SequencerState directly)
+```
+
+`SongAdvance` must be handled outside `apply_command` because it needs access
+to the `Song` (stored in UI/song layer, not `SequencerState`). The command
+processor receives `SongAdvance`, looks up the song's next slot, loads the
+pattern file, then calls `apply_pattern_to_state` under the write lock.
+
+This means the song data (`Song` struct) must live somewhere the command
+processor can access. Two options:
+
+- **Option A (chosen):** Wrap `Song` in a second `Arc<RwLock<Option<Song>>>` passed
+  to the command-processor thread. When `SongAdvance` arrives, the processor
+  reads the song, determines the next slot, loads the pattern, and applies it.
+- **Option B:** Inline the song Vec into `SequencerState`. Rejected because it
+  mixes concerns (sequencer state vs. song arrangement) and adds heap allocation
+  to an otherwise allocation-free hot path.
+
+---
+
+## TUI Changes
+
+### F9/F10 mode switching
+
+In `translate_key` (`engine/src/ui.rs`), in the `to_simple` crossterm→simple
+conversion, add:
+
+```rust
+KeyCode::F(9)  => KeyCodeSimple::F9,
+KeyCode::F(10) => KeyCodeSimple::F10,
+```
+
+And to `KeyCodeSimple` enum:
+```rust
+F9,
+F10,
+```
+
+In `global_key_to_command`:
+```rust
+KeyCodeSimple::F9  => Some(InputCommand::SwitchToPatternMode),
+KeyCodeSimple::F10 => Some(InputCommand::SwitchToSongMode),
+```
+
+`UiState` gains a field mirroring the active mode:
+```rust
+pub play_mode: PlayMode,
+```
+Updated in the `SwitchToPatternMode` / `SwitchToSongMode` arms of
+`translate_key` (similar to how `SetFocus` updates `ui.focus`).
+
+### Song panel (replaces F1 step grid in song mode)
+
+`render_frame` in `engine/src/ui_render.rs` checks `ui.play_mode`:
+- `PlayMode::Pattern` → existing `render_seq_panel` (no change)
+- `PlayMode::Song` → new `render_song_panel`
+
+`UiLocalSnapshot` gains:
+```rust
+pub play_mode: PlayMode,
+pub song_slots: &'a [PatternRef],   // borrow from ui.song (loaded song's slots)
+pub song_cursor: usize,              // which slot the cursor is on
+pub song_active_slot: usize,         // which slot is currently playing (from SequencerState)
+```
+
+`UiState` gains:
+```rust
+pub play_mode: PlayMode,
+pub song: Option<Song>,
+pub song_cursor: usize,
+```
+
+### `render_song_panel` layout
+
+```
+┌ F1 · SONG ──────────────────────────────────────────────────────────────────┐
+│  [01] verse-A.pat.toml    ×2   ◀ playing                                    │
+│  [02] chorus.pat.toml     ×1   ◀ cursor                                     │
+│  [03] bridge.pat.toml     ×1                                                 │
+│  [04] chorus.pat.toml     ×1                                                 │
+│  [05] outro.pat.toml      ×1                                                 │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+Each row: slot number (1-indexed), filename (truncated to 30 chars), repeat
+count (`×N`), and an indicator if it is the currently-playing slot or the
+cursor position.
+
+Colors follow the existing palette:
+- Cursor row: MAGENTA border style (matches playhead highlight convention)
+- Active playing row: CYAN
+- All others: DIM_CYAN/GRAY
+
+### Song-mode key bindings (when F1 has focus and play_mode == Song)
+
+| Key | Action |
+|-----|--------|
+| Up | `SongSlotCursorUp` |
+| Down | `SongSlotCursorDown` |
+| Delete / `d` | `SongSlotDelete` |
+| `i` | (prompt in CLI: `song insert <filename>`) |
+| `[` | `SongSlotMoveUp` |
+| `]` | `SongSlotMoveDown` |
+
+Insertion is done via the CLI panel (F4) to avoid needing an inline text
+editor in the song panel.
+
+### Key bind bar update
+
+The existing `render_keybind_bar` is a static string. In song mode it should
+show song-specific hints. Two approaches:
+- **Option A (chosen):** make `render_keybind_bar` accept `play_mode` and
+  switch the hint string.
+- **Option B:** always show pattern hints. Simpler but confusing.
+
+### F9/F10 status in title bar
+
+The title bar currently shows `▶ 217 Industries / midi-man-mk3`. Add a mode
+indicator: `[PAT]` or `[SONG]` after the project name.
+
+---
+
+## CLI Additions
+
+New commands added to `handle_cli_submit` in `engine/src/ui.rs`:
+
+| Command | Action |
+|---------|--------|
+| `pattern save <name>` | Serialize current state to `<name>.pat.toml` |
+| `pattern load <name>` | Load `<name>.pat.toml` into current state |
+| `pattern list` | List `.pat.toml` files in pattern dir, log each |
+| `song new <name>` | Create empty song, set as active song |
+| `song load <name>` | Load `<name>.song.toml` |
+| `song save <name>` | Save current `ui.song` to `<name>.song.toml` |
+| `song list` | List `.song.toml` files in song dir |
+| `song add <filename>` | Append `<filename>.pat.toml` slot to current song |
+| `song remove <n>` | Remove slot at 1-indexed position `n` |
+| `song set-repeats <n> <r>` | Set repeat count for slot `n` to `r` |
+
+These are handled entirely within `handle_cli_submit` (or a new helper
+`handle_cli_song_cmd`). They produce `LogTag::Cmd` on success and `LogTag::Err`
+on failure. Pattern/song disk operations are performed synchronously in the UI
+thread (not via `InputCommand`) because they produce log output and the UI
+thread already owns `UiState`.
+
+`HELP_ENTRIES` in `engine/src/ui.rs` is extended with all new commands.
+
+---
+
+## Step-by-Step Implementation Plan
+
+### Step 1 — Dependencies (prerequisite for all)
+
+**File:** `engine/Cargo.toml`
+
+Add:
+```toml
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+```
+
+`toml` 0.8.x is the current stable release (as of 2025) with full
+serialize/deserialize support. No other steps can proceed until this builds.
+
+Agent type: Coder. Expected test: `cargo build -p engine` succeeds.
+
+### Step 2 — `pattern.rs` module (data model + file I/O)
+
+**File:** `engine/src/pattern.rs` (new)
+**File:** `engine/src/lib.rs` — add `pub mod pattern;`
+
+Implement:
+- `StepDataSerial`, `PatternData`, `PatternRef`, `Song` with full
+  `Serialize`/`Deserialize` derives
+- `pattern_dir()`, `song_dir()` using `dirs::home_dir()` or `std::env::var("HOME")`
+  — no `dirs` crate needed; use `std::env::var("HOME").unwrap_or_else(|_| "/tmp".into())`
+- `save_pattern`, `load_pattern`, `save_song`, `load_song`
+- `pattern_from_state`, `apply_pattern_to_state`
+- Helper functions: `key_to_str/str_to_key`, `mode_to_str/str_to_mode`,
+  `step_size_to_str/str_to_step_size`, `tempo_roll_point_to_str/str_to_tempo_roll_point`,
+  `tempo_rand_type_to_str/str_to_tempo_rand_type`
+
+Unit tests (no disk I/O): roundtrip `pattern_from_state` → serialize to TOML
+string → deserialize → `apply_pattern_to_state`, assert key fields survive.
+Use `toml::to_string` / `toml::from_str` directly in tests (no filesystem).
+
+Dependency: Step 1.
+
+### Step 3 — State changes (`state.rs`)
+
+**File:** `engine/src/state.rs`
+
+- Add `PlayMode` enum with `Default`
+- Add fields to `SequencerState`: `play_mode`, `song_slot_index`,
+  `song_slot_repeat`
+- Change `tick()` return type from `Option<MidiEvent>` to `TickResult` enum
+- Add `SwitchToPatternMode`, `SwitchToSongMode` variants to `InputCommand`
+  (in `engine/src/input.rs`)
+- Add `apply_command` arms for the two new mode-switch commands
+- Update `SequencerState::default()` for new fields
+
+`TickResult::PatternEnd` is emitted when `play_mode == Song` and the playhead
+wraps. `tick()` still returns `TickResult::Note(event)` for normal steps.
+For pattern mode, the existing `None` → `TickResult::Idle` and
+`Some(event)` → `TickResult::Note(event)`.
+
+Update all call sites of `tick()`:
+- `engine/src/clock.rs` — the primary consumer; handle `PatternEnd` by sending
+  `InputCommand::SongAdvance` on a new `cmd_tx` reference the clock holds.
+
+**Clock thread signature change:** `run_clock` must also accept a
+`SyncSender<InputCommand>` to forward `SongAdvance`. Update `main.rs` to
+pass a clone of `cmd_tx` to `run_clock`.
+
+Dependency: Steps 1–2.
+
+Unit tests: `tick()` in pattern mode returns `Idle`/`Note` unchanged;
+in song mode returns `PatternEnd` on wrap.
+
+### Step 4 — `KeyCodeSimple` + `global_key_to_command` (F9/F10)
+
+**File:** `engine/src/input.rs`
+
+- Add `F9`, `F10` variants to `KeyCodeSimple`
+- Add `F9`/`F10` arms to `to_simple()` in `engine/src/ui.rs` (crossterm mapping)
+- Add arms in `global_key_to_command`:
+  ```rust
+  KeyCodeSimple::F9  => Some(InputCommand::SwitchToPatternMode),
+  KeyCodeSimple::F10 => Some(InputCommand::SwitchToSongMode),
+  ```
+
+- Add `SongSlotCursorUp`, `SongSlotCursorDown`, `SongSlotDelete`,
+  `SongSlotMoveUp`, `SongSlotMoveDown` to `InputCommand` enum.
+
+Unit tests: `global_key_to_command(F9)` → `SwitchToPatternMode`,
+`global_key_to_command(F10)` → `SwitchToSongMode`.
+
+Dependency: Step 3.
+
+### Step 5 — `UiState` + song state in UI layer
+
+**File:** `engine/src/ui.rs`
+
+- Add `play_mode: PlayMode`, `song: Option<Song>`, `song_cursor: usize` to
+  `UiState`
+- `UiState::new()` defaults: `play_mode = PlayMode::Pattern`, `song = None`,
+  `song_cursor = 0`
+- In `translate_key`, handle `SwitchToPatternMode` / `SwitchToSongMode` by
+  updating `ui.play_mode` (mirrors how `SetFocus` updates `ui.focus`)
+- In `translate_key`, when `FocusPanel::Sequencer` and
+  `ui.play_mode == PlayMode::Song`, map Up/Down arrow to `SongSlotCursorUp` /
+  `SongSlotCursorDown` (updating `ui.song_cursor` locally); map `d` to
+  `SongSlotDelete`; map `[`/`]` to move commands.
+
+**Song Arc**: In `main.rs`, create
+`Arc<RwLock<Option<Song>>>` and pass it to both the command processor thread
+and (as a read reference) to the UI via a channel or direct arc clone. The
+simplest approach: UI thread owns `Option<Song>` directly (no arc needed for
+the list display); song state for the command processor is delivered via
+`InputCommand` — specifically `SongAdvance` carries enough info because the
+processor looks up the next slot index from the arc.
+
+Revised approach for simplicity: the `Song` is owned by `UiState`; the
+command processor receives `InputCommand::SongLoadSlot { filename: String }`
+instead of `SongAdvance`. The clock sends `SongAdvance`; the command processor
+retrieves the next filename by reading `Arc<RwLock<Option<Song>>>`, then loads
+the pattern and applies it. This cleanly separates concerns.
+
+**`Arc<RwLock<Option<Song>>>`** passed to:
+1. Command-processor thread (to look up slot on `SongAdvance`)
+2. `run_ui` (to update when song is loaded/changed via CLI)
+
+Dependency: Steps 3–4.
+
+### Step 6 — CLI song/pattern commands
+
+**File:** `engine/src/ui.rs`
+
+Extend `handle_cli_submit` with all new `pattern *` and `song *` commands.
+Add `handle_cli_pattern_cmd` and `handle_cli_song_cmd` private helpers matching
+the style of `handle_cli_note_set`.
+
+Each successful disk operation pushes a `LogTag::Cmd` entry; errors push
+`LogTag::Err`.
+
+Update `HELP_ENTRIES` with all new commands.
+
+Write unit tests for each new branch using the same `make_channels()` / `UiState`
+pattern already in the test module, using `toml::to_string` mocks rather than
+actual disk I/O (pass a custom pattern dir via a test env var, or abstract the
+dir resolver behind a trait — simplest: just call `toml::from_str`/`to_string`
+directly in unit tests without touching disk).
+
+Dependency: Steps 2, 5.
+
+### Step 7 — `UiLocalSnapshot` + `render_song_panel`
+
+**File:** `engine/src/ui_render.rs`
+
+- Add `play_mode`, `song_slots`, `song_cursor`, `song_active_slot` fields to
+  `UiLocalSnapshot`
+- In `render_frame`, branch on `ui.play_mode`:
+  - `Pattern` → existing `render_seq_panel(…, chunks[2])`
+  - `Song` → new `render_song_panel(…, chunks[2])`
+- Implement `render_song_panel`: vertical list, each slot one row, cursor/active
+  highlights, slot number, filename, repeat count
+- Update `render_keybind_bar` to accept `PlayMode` and switch hint string
+- Update title bar to append `[PAT]` or `[SONG]`
+
+`UiLocalSnapshot` is assembled in `run_ui` each frame; update the assembly in
+`engine/src/ui.rs` to populate the new fields from `ui.play_mode`, `ui.song`,
+`ui.song_cursor`, and the state snapshot's `song_slot_index`.
+
+Unit tests: `render_song_panel` does not panic with empty slot list; with 3
+slots renders all slot numbers; cursor row contains a distinguishable marker.
+Use `TestBackend` exactly as existing render tests do.
+
+Dependency: Steps 3–5.
+
+### Step 8 — `SongAdvance` command-processor wiring in `main.rs`
+
+**File:** `engine/src/main.rs`
+
+- Add `Arc<RwLock<Option<Song>>>` construction and sharing
+- Pass `cmd_tx.clone()` to `run_clock` (clock needs to send `SongAdvance`)
+- Pass the song arc to the command-processor closure and to `run_ui`
+- In the command-processor loop, handle `InputCommand::SongAdvance`:
+  1. Read the song arc (read lock)
+  2. Look up next slot (accounting for `song_slot_index` and `song_slot_repeat`)
+  3. Load pattern from disk
+  4. Acquire write lock on state, call `apply_pattern_to_state`
+  5. Update `song_slot_index` / `song_slot_repeat` in state
+
+Dependency: Steps 3–7.
+
+### Step 9 — Integration test + acceptance verification
+
+**File:** `engine/tests/song_mode.rs` (new)
+
+Tests (no hardware):
+- `pattern_roundtrip`: create `SequencerState`, call `pattern_from_state`,
+  serialize to TOML string, deserialize, apply to a new `SequencerState`,
+  verify key fields.
+- `song_roundtrip`: create `Song` with 3 slots, serialize, deserialize,
+  verify slot count and filenames.
+- `tick_returns_pattern_end_in_song_mode`: set `play_mode = Song`,
+  advance playhead to loop_out, call tick, expect `TickResult::PatternEnd`.
+- `f9_f10_global_key`: `global_key_to_command(F9)` → `SwitchToPatternMode`.
+
+Dependency: Steps 1–8.
+
+---
+
+## Acceptance Criteria
+
+### AC-1: Pattern save/load
+- [ ] `pattern save verse-A` creates `~/.config/midi-man-mk3/patterns/verse-A.pat.toml`
+- [ ] File is valid TOML parseable by hand
+- [ ] `pattern load verse-A` restores all step data, key, mode, tempo to previous values
+
+### AC-2: Song file
+- [ ] `song new my-song` creates an empty song
+- [ ] `song add verse-A` appends a slot; `song save my-song` writes the file
+- [ ] `song load my-song` restores the slot list
+- [ ] `song remove 2` removes the second slot (1-indexed)
+
+### AC-3: Song playback
+- [ ] In song mode, when a pattern finishes its repeats, the next slot loads and plays without silence gap longer than one tick
+- [ ] Song wraps to slot 0 after the last slot plays
+- [ ] `song_slot_index` in state advances correctly
+
+### AC-4: F9/F10 switching
+- [ ] F9 transitions to pattern mode; F1 panel shows the 16-step grid
+- [ ] F10 transitions to song mode; F1 panel shows the slot list
+- [ ] Title bar shows `[PAT]` / `[SONG]` accordingly
+- [ ] Switching mode does not stop playback
+
+### AC-5: Song panel TUI
+- [ ] Vertical slot list renders without panic for 0, 1, and 50+ slots
+- [ ] Cursor is visually distinct (MAGENTA row highlight)
+- [ ] Active playing slot is highlighted (CYAN)
+- [ ] Up/Down arrows move the cursor when F1 has focus in song mode
+
+### AC-6: CLI commands
+- [ ] All new commands appear in `help` output
+- [ ] Unknown patterns or songs produce `LogTag::Err` entries
+- [ ] `pattern list` and `song list` log available files
+
+### AC-7: No regressions
+- [ ] All existing tests pass (`cargo test -p engine`)
+- [ ] Pattern mode behavior (F9 or default) is identical to pre-song-mode behavior
+- [ ] Tick timing is unaffected by song mode when in pattern mode
+
+---
+
+## Trade-offs
+
+### Pattern transition: in-place state mutation vs. thread restart
+
+**Option A (chosen): apply pattern to running state under write lock.**
+The clock thread is not paused; the pattern swap happens in the command
+processor on `SongAdvance`. There is a possible one-tick gap: the clock
+advances the playhead before the pattern is loaded, producing a stale step.
+Acceptable for a sequencer (hardware grooveboxes do the same). Mitigation: the
+command processor is higher priority than `thread::spawn` default; the gap is
+sub-millisecond on a modern system.
+
+**Option B: pause the clock, swap state, resume.** Eliminates the stale-step
+risk but adds significant complexity (a third channel back from the command
+processor to the clock, or a `Condvar`). Overkill for this use case.
+
+### Song data storage: UI-owned vs. state-owned
+
+**Option A (chosen): Song in `UiState` + `Arc<RwLock<Option<Song>>>` for
+cross-thread access.** Keeps `SequencerState` free of heap-allocated song data.
+The command processor reads the arc on `SongAdvance`.
+
+**Option B: inline `Song` into `SequencerState`.** Simpler thread wiring
+(no second arc) but adds `Vec` allocation to a struct that is otherwise
+`Clone`-by-copy-fields. Also makes the song changeable via `apply_command`
+which conflates sequencer concerns with song management concerns. Rejected.
+
+### File format: TOML vs. JSON vs. binary
+
+TOML is confirmed by operator. JSON would be equally achievable with the same
+dependencies (serde). Binary (e.g. bincode) would be smaller but not
+human-editable. TOML wins on readability and is standard in the Rust ecosystem.
+
+### Slot cursor: UiState-local vs. state-tracked
+
+The slot cursor (which slot the user is navigating in the song panel) is UI-
+only. It does not need to be in `SequencerState` because no other thread
+reads it. However, `song_slot_index` (which slot is currently playing) must
+be in `SequencerState` so the clock/render can read it under the read lock.
+These are distinct fields and must not be conflated.
+
+---
+
+## Dependencies and Prerequisites
+
+### New crate dependencies
+
+Add to `engine/Cargo.toml` `[dependencies]`:
+
+```toml
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+```
+
+`serde` 1.x and `toml` 0.8.x are the current stable series. `toml` 0.8
+depends on `serde` 1; there is no version conflict with the transitively-
+present `serde` 1.0.228. After adding, run `cargo build -p engine` to verify
+the lockfile resolves cleanly.
+
+No other new external crates are needed. Filesystem access uses `std::fs` and
+`std::path::PathBuf` from std. The `HOME` environment variable is used to
+derive the config directory; no platform-specific crate is required.
+
+### Environment / config directory
+
+The directory `~/.config/midi-man-mk3/` is created automatically by
+`pattern_dir()` / `song_dir()` via `std::fs::create_dir_all`. No migration
+is needed for existing users (there are no existing files). No `.env` changes.
+
+### Source files created or modified
+
+| File | Change |
+|------|--------|
+| `engine/Cargo.toml` | Add `serde`, `toml` dependencies |
+| `engine/src/pattern.rs` | New — data model and file I/O |
+| `engine/src/lib.rs` | Add `pub mod pattern;` |
+| `engine/src/state.rs` | Add `PlayMode`, `TickResult`, new state fields, new `InputCommand` variants |
+| `engine/src/input.rs` | Add `F9`, `F10` to `KeyCodeSimple`; add new `InputCommand` variants |
+| `engine/src/ui.rs` | Add song fields to `UiState`; extend `translate_key`, `handle_cli_submit`, `HELP_ENTRIES`; extend `UiLocalSnapshot` assembly |
+| `engine/src/ui_render.rs` | Add `play_mode`/song fields to `UiLocalSnapshot`; add `render_song_panel`; update `render_keybind_bar` and title bar |
+| `engine/src/clock.rs` | Accept `SyncSender<InputCommand>`; handle `TickResult::PatternEnd` |
+| `engine/src/main.rs` | Wire song arc; pass `cmd_tx` clone to clock; extend command processor |
+| `engine/tests/song_mode.rs` | New — integration tests |
+
+---
+
+## Summary: Key Decisions, Affected Files, Recommended Order
+
+**Key decisions:**
+- Pattern and song files are TOML in `~/.config/midi-man-mk3/patterns/` and
+  `.../songs/`
+- Song mode replaces the F1 zone; it does not add a new layout zone
+- `tick()` return type changes to `TickResult` to signal pattern-end cleanly
+- The clock thread receives a `cmd_tx` clone to forward `SongAdvance`
+- Song data lives in `UiState` + `Arc<RwLock<Option<Song>>>` for
+  cross-thread slot lookup; it is not in `SequencerState`
+- Pattern transitions happen in the command-processor thread under a write lock
+  with no clock pause (accepts sub-tick jitter)
+
+**Most affected source files (highest change density):**
+1. `engine/src/state.rs` — new enum, new fields, return type change
+2. `engine/src/ui.rs` — song UiState fields, translate_key, CLI commands
+3. `engine/src/ui_render.rs` — song panel render, snapshot fields
+4. `engine/src/main.rs` — arc wiring, clock signature
+5. `engine/src/pattern.rs` — new file (all new)
+
+**Recommended implementation order (each step is a separately committable unit):**
+1. Step 1 — Cargo.toml dependencies
+2. Step 2 — `pattern.rs` data model + roundtrip tests
+3. Step 3 — `state.rs` + `input.rs` changes (TickResult, PlayMode, new commands)
+4. Step 4 — `KeyCodeSimple` F9/F10 + global key mapping
+5. Step 5 — `UiState` song fields + translate_key song navigation
+6. Step 6 — CLI pattern/song commands
+7. Step 7 — `ui_render.rs` song panel
+8. Step 8 — `main.rs` wiring
+9. Step 9 — Integration tests

--- a/.workflow/tasks/song-mode-01-cargo-deps.md
+++ b/.workflow/tasks/song-mode-01-cargo-deps.md
@@ -1,0 +1,38 @@
+Name: cargo-deps
+Type: coder
+Status: pending
+Repo: /home/whinchman/experiments/midi-man-mk3
+Parallel Group: 1
+Feature Branch: feature/song-mode
+Branch: feature/song-mode/cargo-deps
+Base Branch: feature/song-mode
+Goal: Add serde (with derive feature) and toml 0.8 to engine/Cargo.toml so all subsequent song-mode tasks can compile.
+
+Context:
+  File to modify: engine/Cargo.toml
+
+  Current [dependencies] block (lines 11-17):
+    midir = { version = "0.11", optional = true }
+    hidapi = { version = "2.6", features = ["linux-static-hidraw"], optional = true }
+    ratatui = { version = "0.30", default-features = false, features = ["macros"] }
+    crossterm = { version = "0.29", optional = true }
+    libc = "0.2"
+
+  Add these two lines to the [dependencies] section:
+    serde = { version = "1", features = ["derive"] }
+    toml = "0.8"
+
+  Note: serde 1.x is already transitively present via ratatui but does not
+  have the `derive` feature enabled; it must be added as a direct dep. toml 0.8
+  depends on serde 1 — no version conflict exists. Do NOT touch [features].
+
+  After editing, verify the lockfile resolves cleanly:
+    cargo build -p engine
+
+Acceptance Criteria:
+  - [ ] engine/Cargo.toml [dependencies] contains `serde = { version = "1", features = ["derive"] }`
+  - [ ] engine/Cargo.toml [dependencies] contains `toml = "0.8"`
+  - [ ] `cargo build -p engine` succeeds with no errors
+  - [ ] `cargo test -p engine` continues to pass (no regressions)
+
+Dependencies: (none — this is the root task)

--- a/.workflow/tasks/song-mode-02-pattern-module.md
+++ b/.workflow/tasks/song-mode-02-pattern-module.md
@@ -1,0 +1,129 @@
+Name: pattern-module
+Type: coder
+Status: pending
+Repo: /home/whinchman/experiments/midi-man-mk3
+Parallel Group: 2
+Feature Branch: feature/song-mode
+Branch: feature/song-mode/pattern-module
+Base Branch: feature/song-mode
+Goal: Create engine/src/pattern.rs with all serializable data structs, TOML file I/O helpers, and roundtrip unit tests.
+
+Context:
+  Files to create/modify:
+    engine/src/pattern.rs  (new file — all content below)
+    engine/src/lib.rs      (add `pub mod pattern;` after the existing `pub mod state;` line)
+
+  ## Structs to implement
+
+  All structs derive `Serialize, Deserialize, Clone, Debug` from serde.
+
+  ```rust
+  pub struct StepDataSerial {
+      pub enabled: bool,
+      pub midi_note: u8,
+      pub velocity: u8,
+  }
+
+  pub struct PatternData {
+      pub name: String,
+      pub steps: Vec<StepDataSerial>,   // exactly 16 elements
+      pub key: String,                  // e.g. "C", "C#"
+      pub mode: String,                 // e.g. "Major", "NaturalMinor"
+      pub tempo_bpm: u16,
+      pub swing: i8,
+      pub step_size: String,            // e.g. "1/16", "1/8"
+      pub loop_in: u8,
+      pub loop_out: u8,
+      pub loop_active: bool,
+      pub midi_channel: u8,
+      pub scale_quant: bool,
+      pub note_modifier: i8,
+      pub velocity_modifier: i8,
+      pub skip_modifier: bool,
+      pub tempo_rand: u8,
+      pub tempo_roll_point: String,
+      pub tempo_variance_max: u8,
+      pub tempo_rand_type: String,
+      pub step_rand: u8,
+      pub note_rand: u8,
+  }
+
+  pub struct PatternRef {
+      pub filename: String,   // just filename, e.g. "verse-A.pat.toml"
+      pub repeats: u8,        // 1 = play once; default 1
+  }
+
+  pub struct Song {
+      pub name: String,
+      pub slots: Vec<PatternRef>,
+  }
+  ```
+
+  ## File I/O helpers
+
+  Use `std::env::var("HOME").unwrap_or_else(|_| "/tmp".into())` to derive the
+  config root. Do NOT add the `dirs` crate.
+
+  ```rust
+  pub fn pattern_dir() -> PathBuf  // ~/.config/midi-man-mk3/patterns/
+  pub fn song_dir() -> PathBuf     // ~/.config/midi-man-mk3/songs/
+
+  pub fn save_pattern(data: &PatternData, filename: &str) -> Result<(), String>
+  pub fn load_pattern(filename: &str) -> Result<PatternData, String>
+  pub fn save_song(song: &Song, filename: &str) -> Result<(), String>
+  pub fn load_song(filename: &str) -> Result<Song, String>
+  ```
+
+  All four I/O helpers must call `std::fs::create_dir_all` on the relevant dir
+  before any file operation. Errors are mapped to `String` via `.map_err(|e| e.to_string())`.
+
+  ## Conversion helpers
+
+  ```rust
+  pub fn pattern_from_state(state: &SequencerState, name: &str) -> PatternData
+  pub fn apply_pattern_to_state(data: &PatternData, state: &mut SequencerState) -> Result<(), String>
+  ```
+
+  `pattern_from_state` reads every serializable field from `SequencerState` and converts
+  enum variants to their string forms.
+
+  `apply_pattern_to_state` parses string-encoded fields back to their enum variants.
+  Return `Err("unrecognized key: <value>")` (and similar) if any string is unknown.
+
+  Private helpers for each enum conversion (all must be exhaustive):
+    key_to_str / str_to_key  (crate::music_theory::Key — see existing variants in state.rs)
+    mode_to_str / str_to_mode (crate::music_theory::Mode)
+    step_size_to_str / str_to_step_size (crate::state::StepSize — Whole/Half/Quarter/Eighth/Sixteenth/ThirtySecond)
+    tempo_roll_point_to_str / str_to_tempo_roll_point (Off/Step/Beat/Seq)
+    tempo_rand_type_to_str / str_to_tempo_rand_type (Random/Up/Down/Breathe/PingPong)
+
+  ## TOML file extensions
+    Pattern files: `<name>.pat.toml` (pattern_dir / <filename>)
+    Song files:    `<name>.song.toml` (song_dir / <filename>)
+
+  ## Unit tests (no disk I/O)
+  Tests go in a `#[cfg(test)] mod tests` block at the bottom of pattern.rs.
+  Use `toml::to_string` / `toml::from_str` directly — no filesystem calls.
+
+  Test cases required:
+  - `pattern_roundtrip`: build a default `SequencerState`, call `pattern_from_state`,
+    serialize to TOML string with `toml::to_string`, deserialize back with
+    `toml::from_str::<PatternData>`, call `apply_pattern_to_state` on a fresh state,
+    assert tempo_bpm, key string, step count (16), and a step's midi_note all survive.
+  - `song_roundtrip`: construct a `Song` with 3 `PatternRef` slots, serialize and
+    deserialize, assert `slots.len() == 3` and filenames are preserved.
+  - `unknown_key_returns_err`: call `str_to_key("ZZZZ")` and assert it returns `Err`.
+
+  ## Existing enum locations (for imports)
+  - `crate::music_theory::{Key, Mode}` — Key and Mode enums
+  - `crate::state::{SequencerState, StepSize, TempoRollPoint, TempoRandType}`
+
+Acceptance Criteria:
+  - [ ] engine/src/pattern.rs exists with all four structs, all I/O helpers, all conversion helpers
+  - [ ] engine/src/lib.rs has `pub mod pattern;`
+  - [ ] `cargo test -p engine pattern` passes (all three unit tests in pattern.rs)
+  - [ ] `cargo build -p engine` succeeds with no warnings about unused items in pattern.rs
+  - [ ] All 16 steps survive the roundtrip test (count check)
+  - [ ] Disk I/O functions use `create_dir_all` before writing
+
+Dependencies: cargo-deps

--- a/.workflow/tasks/song-mode-03-state-and-input.md
+++ b/.workflow/tasks/song-mode-03-state-and-input.md
@@ -1,0 +1,221 @@
+Name: state-and-input
+Type: coder
+Status: pending
+Repo: /home/whinchman/experiments/midi-man-mk3
+Parallel Group: 3
+Feature Branch: feature/song-mode
+Branch: feature/song-mode/state-and-input
+Base Branch: feature/song-mode
+Goal: Add PlayMode enum, TickResult enum, new SequencerState fields, new InputCommand variants (including F9/F10 KeyCodeSimple variants), and update all call sites of tick().
+
+Context:
+  Files to modify:
+    engine/src/state.rs
+    engine/src/input.rs
+    engine/src/clock.rs   (update tick() call site + accept cmd_tx for SongAdvance)
+
+  NOTE: Steps 3 and 4 from the plan are merged here because they both touch
+  input.rs and have identical dependencies.
+
+  ## Changes to engine/src/state.rs
+
+  ### Add PlayMode enum (near the top, before SequencerState)
+  ```rust
+  #[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+  pub enum PlayMode {
+      #[default]
+      Pattern,
+      Song,
+  }
+  ```
+
+  ### Add TickResult enum (near MidiEvent)
+  ```rust
+  pub enum TickResult {
+      Idle,
+      Note(MidiEvent),
+      PatternEnd,   // song mode only: pattern wrapped, advance to next slot
+  }
+  ```
+
+  ### Add fields to SequencerState
+  ```rust
+  pub play_mode: PlayMode,
+  pub song_slot_index: usize,
+  pub song_slot_repeat: u8,
+  ```
+  All three default to their zero values (PlayMode::Pattern, 0, 0).
+
+  ### Change tick() return type: Option<MidiEvent> -> TickResult
+  Current signature (line 367 of state.rs):
+    pub fn tick(&mut self) -> Option<MidiEvent>
+
+  New signature:
+    pub fn tick(&mut self) -> TickResult
+
+  Conversion rules:
+    - When not playing or paused: was `return None;` → now `return TickResult::Idle;`
+    - When a NoteOn fires: was `Some(MidiEvent::NoteOn { ... })` → `TickResult::Note(MidiEvent::NoteOn { ... })`
+    - After playhead wraps AND `self.play_mode == PlayMode::Song`: instead of
+      resetting playhead and continuing normally, reset the playhead to loop_in (or 0)
+      and `return TickResult::PatternEnd;`
+    - All other `None` returns → `TickResult::Idle`
+
+  The pattern-end detection point is: after computing the new playhead position,
+  if play_mode is Song and the playhead just wrapped (i.e. the new playhead equals
+  loop_in when loop_active, or 0 when not loop_active), emit PatternEnd before
+  the step fires. Specifically: detect the wrap condition BEFORE processing the step,
+  so the new slot loads before its first step fires.
+
+  ### Add apply_command arms
+  In the existing `apply_command` match:
+  ```rust
+  InputCommand::SwitchToPatternMode => {
+      self.play_mode = PlayMode::Pattern;
+  }
+  InputCommand::SwitchToSongMode => {
+      self.play_mode = PlayMode::Song;
+      self.song_slot_index = 0;
+      self.song_slot_repeat = 0;
+  }
+  // SongAdvance is handled by the command processor (has Song access); no-op here.
+  InputCommand::SongAdvance => {}
+  InputCommand::SongSlotCursorUp => {}     // UI-only; state ignores
+  InputCommand::SongSlotCursorDown => {}
+  InputCommand::SongSlotDelete => {}
+  InputCommand::SongSlotMoveUp => {}
+  InputCommand::SongSlotMoveDown => {}
+  InputCommand::SongSlotInsert(_) => {}
+  ```
+
+  ## Changes to engine/src/input.rs
+
+  ### Extend KeyCodeSimple enum
+  After the existing `F4` variant, add:
+  ```rust
+  /// F9 — switch to pattern mode.
+  F9,
+  /// F10 — switch to song mode.
+  F10,
+  /// Delete key.
+  Delete,
+  ```
+
+  ### Add new InputCommand variants
+  After the existing `NoteSet` variant, add:
+  ```rust
+  /// Switch to pattern mode (F9).
+  SwitchToPatternMode,
+  /// Switch to song mode (F10).
+  SwitchToSongMode,
+  /// Advance song to next slot (sent by clock on PatternEnd).
+  SongAdvance,
+  /// Song slot list cursor: move up.
+  SongSlotCursorUp,
+  /// Song slot list cursor: move down.
+  SongSlotCursorDown,
+  /// Insert a pattern slot at cursor position (filename only, no path).
+  SongSlotInsert(String),
+  /// Delete the slot at cursor.
+  SongSlotDelete,
+  /// Swap cursor slot with the slot above it.
+  SongSlotMoveUp,
+  /// Swap cursor slot with the slot below it.
+  SongSlotMoveDown,
+  ```
+
+  ### Add global_key_to_command function (new, in input.rs)
+  ```rust
+  /// Translate a key event that is always active regardless of focus or overlay.
+  /// Currently handles F9/F10 mode switching.
+  pub fn global_key_to_command(key: KeyCodeSimple) -> Option<InputCommand> {
+      match key {
+          KeyCodeSimple::F9  => Some(InputCommand::SwitchToPatternMode),
+          KeyCodeSimple::F10 => Some(InputCommand::SwitchToSongMode),
+          _ => None,
+      }
+  }
+  ```
+
+  ## Changes to engine/src/clock.rs
+
+  ### Update run_clock signature
+  Old: `pub fn run_clock(state: Arc<RwLock<SequencerState>>, midi_tx: SyncSender<MidiEvent>)`
+  New: `pub fn run_clock(state: Arc<RwLock<SequencerState>>, midi_tx: SyncSender<MidiEvent>, cmd_tx: SyncSender<InputCommand>)`
+
+  Add `use crate::input::InputCommand;` to the imports in clock.rs.
+
+  ### Update the tick() call site
+  Old (lines 377-410, roughly):
+  ```rust
+  let maybe_event = {
+      let mut s = state.write()...;
+      s.tick()
+  };
+  if let Some(MidiEvent::NoteOn { channel, note, velocity, .. }) = maybe_event {
+      ...
+  }
+  ```
+
+  New:
+  ```rust
+  let tick_result = {
+      let mut s = state.write().expect("clock: state RwLock poisoned");
+      s.tick()
+  };
+  match tick_result {
+      crate::state::TickResult::Note(MidiEvent::NoteOn { channel, note, velocity, .. }) => {
+          // retrigger + send NoteOn — same logic as before
+          ...
+          last_note = Some((channel, note));
+      }
+      crate::state::TickResult::PatternEnd => {
+          if cmd_tx.send(InputCommand::SongAdvance).is_err() {
+              break;
+          }
+      }
+      _ => {}
+  }
+  ```
+
+  ## Unit tests
+
+  Add to the `#[cfg(test)] mod tests` block in state.rs:
+
+  - `tick_in_pattern_mode_returns_idle_when_not_playing`: default state (playing=false),
+    call tick(), assert matches TickResult::Idle.
+  - `tick_in_song_mode_returns_pattern_end_on_wrap`: set play_mode=Song, playing=true,
+    loop_active=false, set playhead=14 (one before wrap at 15), call tick() twice —
+    second call should return TickResult::PatternEnd.
+  - `switch_to_song_mode_resets_slot_index`: apply SwitchToSongMode, assert
+    song_slot_index==0 and song_slot_repeat==0 and play_mode==Song.
+
+  Add to input.rs tests:
+
+  - `global_key_f9_maps_to_switch_to_pattern_mode`: assert global_key_to_command(F9) ==
+    Some(SwitchToPatternMode).
+  - `global_key_f10_maps_to_switch_to_song_mode`: assert global_key_to_command(F10) ==
+    Some(SwitchToSongMode).
+  - `global_key_other_returns_none`: assert global_key_to_command(F1) == None.
+
+  ## main.rs update (small)
+  In engine/src/main.rs the clock spawn passes only two args:
+    `engine::clock::run_clock(clock_state, clock_midi_tx)`
+  This must become:
+    `engine::clock::run_clock(clock_state, clock_midi_tx, cmd_tx.clone())`
+  Add this change in this task since clock.rs signature changes here.
+  The Song Arc wiring from the plan's Step 8 is deferred to the song-mode-wiring task.
+
+Acceptance Criteria:
+  - [ ] PlayMode and TickResult enums exist and are pub in state.rs
+  - [ ] SequencerState has play_mode, song_slot_index, song_slot_repeat fields with correct defaults
+  - [ ] tick() returns TickResult in all branches; no remaining Option<MidiEvent> return sites
+  - [ ] KeyCodeSimple has F9, F10, Delete variants
+  - [ ] global_key_to_command function exists in input.rs and is pub
+  - [ ] All new InputCommand variants exist (SwitchToPatternMode, SwitchToSongMode, SongAdvance, SongSlotCursorUp/Down/Insert/Delete/MoveUp/MoveDown)
+  - [ ] run_clock signature accepts cmd_tx: SyncSender<InputCommand> as third arg
+  - [ ] main.rs passes cmd_tx.clone() to run_clock
+  - [ ] All 6 new unit tests pass
+  - [ ] `cargo test -p engine` passes with no regressions
+
+Dependencies: pattern-module

--- a/.workflow/tasks/song-mode-04-ui-state-and-cli.md
+++ b/.workflow/tasks/song-mode-04-ui-state-and-cli.md
@@ -1,0 +1,170 @@
+Name: ui-state-and-cli
+Type: coder
+Status: pending
+Repo: /home/whinchman/experiments/midi-man-mk3
+Parallel Group: 4
+Feature Branch: feature/song-mode
+Branch: feature/song-mode/ui-state-and-cli
+Base Branch: feature/song-mode
+Goal: Add song fields to UiState, wire F9/F10 translate_key handling, song panel key navigation, and all new CLI pattern/song commands with HELP_ENTRIES updates.
+
+Context:
+  Files to modify:
+    engine/src/ui.rs  (all changes for both plan step 5 and step 6)
+
+  NOTE: Plan steps 5 and 6 are merged here because they both touch only ui.rs.
+
+  ## 1. Imports to add at the top of ui.rs
+  ```rust
+  use std::sync::{Arc, RwLock};
+  use crate::pattern::{
+      pattern_dir, song_dir,
+      save_pattern, load_pattern,
+      save_song, load_song,
+      pattern_from_state, apply_pattern_to_state,
+      Song, PatternRef,
+  };
+  use crate::state::PlayMode;
+  ```
+
+  ## 2. Add fields to UiState struct
+  After `midi_channel_display: u8` and before `start_time: Instant`:
+  ```rust
+  pub play_mode: PlayMode,
+  pub song: Option<Song>,
+  pub song_cursor: usize,
+  ```
+
+  ## 3. Initialize new fields in UiState::new()
+  ```rust
+  play_mode: PlayMode::Pattern,
+  song: None,
+  song_cursor: 0,
+  ```
+
+  ## 4. Wire F9/F10 in translate_key (hw-io feature gate)
+  translate_key is the function that maps crossterm KeyEvents to InputCommands.
+  It contains a `to_simple` inner conversion from crossterm KeyCode to KeyCodeSimple.
+
+  In the `to_simple` match arm (crossterm → KeyCodeSimple), add after existing F4 arm:
+  ```rust
+  KeyCode::F(9)  => KeyCodeSimple::F9,
+  KeyCode::F(10) => KeyCodeSimple::F10,
+  KeyCode::Delete => KeyCodeSimple::Delete,
+  ```
+
+  After calling `global_key_to_command(simple)`, if Some(cmd) is returned, send it and
+  also update ui.play_mode:
+  ```rust
+  if let Some(cmd) = crate::input::global_key_to_command(simple) {
+      match cmd {
+          InputCommand::SwitchToPatternMode => { ui.play_mode = PlayMode::Pattern; }
+          InputCommand::SwitchToSongMode    => { ui.play_mode = PlayMode::Song; }
+          _ => {}
+      }
+      let _ = cmd_tx.try_send(cmd);
+      return;
+  }
+  ```
+  This must run BEFORE the existing panel-specific routing so F9/F10 are always global.
+
+  ## 5. Song panel key navigation in translate_key
+  When `ui.focus == FocusPanel::Sequencer && ui.play_mode == PlayMode::Song`, map:
+  - Up arrow   → update `ui.song_cursor` (decrement, clamp to 0), send SongSlotCursorUp
+  - Down arrow → update `ui.song_cursor` (increment, clamp to slots.len().saturating_sub(1)), send SongSlotCursorDown
+  - `d` or Delete → send SongSlotDelete; if ui.song.is_some(), remove slot at cursor and clamp cursor
+  - `[` → send SongSlotMoveUp
+  - `]` → send SongSlotMoveDown
+
+  The cursor clamping for Up/Down uses `ui.song.as_ref().map(|s| s.slots.len()).unwrap_or(0)`.
+  The local cursor update in ui.song_cursor mirrors what the engine state will do, keeping
+  the UI cursor in sync without a round-trip.
+
+  ## 6. Extend handle_cli_submit with pattern/song commands
+  Add a new private helper `handle_cli_pattern_cmd` and `handle_cli_song_cmd`.
+  Call them from `handle_cli_submit` before the existing command dispatch:
+  ```rust
+  if parts[0] == "pattern" { return handle_cli_pattern_cmd(parts, ui, state, cmd_tx, arc_song); }
+  if parts[0] == "song"    { return handle_cli_song_cmd(parts, ui, state, cmd_tx, arc_song); }
+  ```
+
+  NOTE: `arc_song: &Arc<RwLock<Option<Song>>>` is a new parameter added to both
+  `handle_cli_submit` and `run_ui`. All existing callers in test code pass a
+  newly-constructed `Arc::new(RwLock::new(None))`.
+
+  ### handle_cli_pattern_cmd — commands:
+  | CLI input | Action |
+  |-----------|--------|
+  | `pattern save <name>` | `pattern_from_state(state, name)` → `save_pattern(&data, &format!("{name}.pat.toml"))` → push LogTag::Cmd on success |
+  | `pattern load <name>` | `load_pattern(&format!("{name}.pat.toml"))` → `apply_pattern_to_state(&data, state)` → send state update → push Cmd/Err |
+  | `pattern list` | `std::fs::read_dir(pattern_dir())` → log each `.pat.toml` filename with LogTag::Info |
+
+  ### handle_cli_song_cmd — commands:
+  | CLI input | Action |
+  |-----------|--------|
+  | `song new <name>` | Set `ui.song = Some(Song { name, slots: vec![] })`, write to arc_song; push Cmd |
+  | `song load <name>` | `load_song(&format!("{name}.song.toml"))` → set ui.song, write to arc_song; push Cmd/Err |
+  | `song save <name>` | `save_song(ui.song.as_ref().unwrap_or_err, ...)` → push Cmd/Err |
+  | `song list` | `std::fs::read_dir(song_dir())` → log each `.song.toml` filename |
+  | `song add <filename>` | Append `PatternRef { filename: format!("{filename}.pat.toml"), repeats: 1 }` to ui.song; write arc_song |
+  | `song remove <n>` | Remove slot at 1-indexed position n from ui.song; write arc_song |
+  | `song set-repeats <n> <r>` | Set slot n's repeat count to r; write arc_song |
+
+  "write arc_song" means: `*arc_song.write().unwrap() = ui.song.clone();`
+
+  Errors (missing song, bad index, parse failure, disk error) push `LogTag::Err`.
+
+  ## 7. Update HELP_ENTRIES
+  Extend the existing `HELP_ENTRIES` constant with:
+  ```rust
+  ("pattern save <name>", "save current pattern to <name>.pat.toml"),
+  ("pattern load <name>", "load pattern from <name>.pat.toml into current state"),
+  ("pattern list", "list saved pattern files"),
+  ("song new <name>", "create a new empty song"),
+  ("song load <name>", "load song from <name>.song.toml"),
+  ("song save <name>", "save current song to <name>.song.toml"),
+  ("song list", "list saved song files"),
+  ("song add <filename>", "append a pattern slot to the current song"),
+  ("song remove <n>", "remove slot at 1-indexed position n"),
+  ("song set-repeats <n> <r>", "set repeat count for slot n to r"),
+  ```
+
+  ## Unit tests
+  Add to the `#[cfg(test)] mod tests` block in ui.rs (use the existing make_channels()
+  pattern already present in ui.rs tests):
+
+  - `pattern_save_pushes_cmd_log`: construct a UiState and a default SequencerState,
+    call handle_cli_pattern_cmd with parts=["pattern","save","test-pat"], assert the
+    log contains a LogTag::Cmd entry. Use a temp dir via `std::env::temp_dir()` by
+    setting HOME env var or mocking pattern_dir to /tmp/... — simplest: the test can
+    call `toml::to_string` directly on a PatternData without disk I/O if you refactor
+    the save into a helper that accepts a PathBuf; otherwise just let the test write to /tmp.
+  - `song_new_creates_empty_song`: call handle_cli_song_cmd with ["song","new","my-song"],
+    assert ui.song.is_some() and ui.song.unwrap().slots.is_empty().
+  - `song_add_appends_slot`: call song new then song add "verse-A", assert slots.len()==1
+    and slots[0].filename=="verse-A.pat.toml".
+  - `song_remove_removes_slot`: add two slots, remove slot 1, assert len==1.
+  - `unknown_pattern_cmd_pushes_err`: call handle_cli_pattern_cmd with ["pattern","frobnicate"],
+    assert LogTag::Err in log.
+
+  ## run_ui signature note (hw-io gated)
+  run_ui already takes `Arc<RwLock<SequencerState>>` and `SyncSender<InputCommand>`.
+  Add `arc_song: Arc<RwLock<Option<Song>>>` as a new parameter and thread it into
+  the translate_key / handle_cli_submit calls. In main.rs, construct the arc and pass it:
+    `let arc_song: Arc<RwLock<Option<Song>>> = Arc::new(RwLock::new(None));`
+  Pass `Arc::clone(&arc_song)` to run_ui. The same arc will be passed to the
+  command-processor in the song-mode-wiring task.
+
+Acceptance Criteria:
+  - [ ] UiState has play_mode, song, song_cursor fields with correct defaults
+  - [ ] translate_key maps F(9)→KeyCodeSimple::F9 and F(10)→KeyCodeSimple::F10
+  - [ ] global_key_to_command is called before panel routing; F9/F10 update ui.play_mode
+  - [ ] Up/Down/d/Delete/[/] navigate song slots when Sequencer focus + Song mode
+  - [ ] handle_cli_submit routes "pattern" and "song" to their helpers
+  - [ ] All 10 CLI commands described above are handled (success and error paths)
+  - [ ] HELP_ENTRIES contains all 10 new entries
+  - [ ] All 5 unit tests pass
+  - [ ] `cargo test -p engine` passes with no regressions
+  - [ ] arc_song is threaded through run_ui and main.rs
+
+Dependencies: state-and-input

--- a/.workflow/tasks/song-mode-05-ui-render.md
+++ b/.workflow/tasks/song-mode-05-ui-render.md
@@ -1,0 +1,140 @@
+Name: ui-render
+Type: coder
+Status: pending
+Repo: /home/whinchman/experiments/midi-man-mk3
+Parallel Group: 4
+Feature Branch: feature/song-mode
+Branch: feature/song-mode/ui-render
+Base Branch: feature/song-mode
+Goal: Add song-mode fields to UiLocalSnapshot, implement render_song_panel, update render_keybind_bar with play_mode-aware hints, and add [PAT]/[SONG] label to the title bar.
+
+Context:
+  Files to modify:
+    engine/src/ui_render.rs   (primary changes)
+    engine/src/ui.rs          (update UiLocalSnapshot assembly in run_ui)
+
+  ## 1. New imports in ui_render.rs
+  ```rust
+  use crate::pattern::PatternRef;
+  use crate::state::PlayMode;
+  ```
+
+  ## 2. Extend UiLocalSnapshot<'a>
+  Current struct ends with `midi_channel_display: u8`. Add:
+  ```rust
+  pub play_mode: PlayMode,
+  pub song_slots: &'a [PatternRef],     // empty slice when no song loaded
+  pub song_cursor: usize,               // which slot the cursor is on
+  pub song_active_slot: usize,          // from SequencerState::song_slot_index
+  ```
+
+  ## 3. Update render_frame to branch on play_mode
+  In `render_frame`, locate the call to `render_seq_panel(frame, snap, state, chunks[2])`.
+  Replace with:
+  ```rust
+  match snap.play_mode {
+      PlayMode::Pattern => render_seq_panel(frame, snap, state, chunks[2]),
+      PlayMode::Song    => render_song_panel(frame, snap, chunks[2]),
+  }
+  ```
+
+  ## 4. Implement render_song_panel
+  ```rust
+  fn render_song_panel(frame: &mut Frame, snap: &UiLocalSnapshot, area: Rect) {
+      // ...
+  }
+  ```
+
+  Layout: a single `Block` with border and title "F1 · SONG" (or "F1 · SEQ" when
+  pattern mode — title bar label is handled in render_keybind_bar, not here).
+
+  Each slot renders as one `Line`:
+  ```
+   [01] verse-A.pat.toml               ×2   ◀ playing
+   [02] chorus.pat.toml                ×1   ◀
+  ```
+  Format: `" [{:02}] {:<30} ×{:<3} {}"`, where:
+  - Index is 1-based
+  - Filename is truncated to 30 chars (use `chars().take(30).collect::<String>()`)
+  - Repeat count
+  - Indicator: "◀ playing" if this slot == song_active_slot; empty otherwise
+
+  Row coloring (using the existing palette consts already in ui_render.rs):
+  - Cursor row (song_cursor == index): style fg=MAGENTA
+  - Active playing row (song_active_slot == index): style fg=CYAN
+  - Other rows: style fg=DIM_CYAN
+
+  A row can be both cursor and active — cursor takes precedence for color.
+
+  If snap.song_slots is empty, render a single dim row: "  (no song loaded)"
+
+  ## 5. Update render_keybind_bar
+  The existing function renders a static hint string. Accept `play_mode: PlayMode`
+  and switch the hint string. Update its signature:
+  ```rust
+  fn render_keybind_bar(frame: &mut Frame, snap: &UiLocalSnapshot, area: Rect)
+  ```
+  (It already receives snap; add a branch inside the function body that reads snap.play_mode.)
+
+  Pattern mode hint (existing or adjusted): show existing F1-F4 focus hints.
+  Song mode hint (new): "F1:SONG  ↑↓:cursor  d:delete  [:move↑  ]:move↓  F9:PAT  F10:SONG"
+
+  ## 6. Title bar [PAT] / [SONG] label
+  Locate the title bar render (it currently contains "▶ 217 Industries / midi-man-mk3").
+  After the project name, append:
+  - `[PAT]` when `snap.play_mode == PlayMode::Pattern`
+  - `[SONG]` when `snap.play_mode == PlayMode::Song`
+
+  ## 7. Update UiLocalSnapshot assembly in ui.rs
+  In `run_ui` (hw-io gate), where `UiLocalSnapshot { ... }` is constructed each frame,
+  add the new fields:
+  ```rust
+  play_mode: ui.play_mode,
+  song_slots: ui.song.as_ref().map(|s| s.slots.as_slice()).unwrap_or(&[]),
+  song_cursor: ui.song_cursor,
+  song_active_slot: state_snap.song_slot_index,  // read from SequencerState snapshot
+  ```
+  The state snapshot is the cloned SequencerState already read under a read lock each frame.
+
+  ## Unit tests
+  Add tests using `ratatui::backend::TestBackend` exactly as the existing render tests do:
+  - `render_song_panel_empty_slots_does_not_panic`: construct a UiLocalSnapshot with
+    song_slots=&[], call render_frame, assert no panic.
+  - `render_song_panel_three_slots_renders_all_numbers`: construct snap with 3 PatternRef
+    slots (filenames "a.pat.toml", "b.pat.toml", "c.pat.toml"), render, capture output
+    as string, assert "[01]", "[02]", "[03]" all appear.
+  - `render_song_panel_cursor_row_differs`: with cursor=1, assert the rendered buffer
+    for row 1 has a different style than row 0 (or just assert the output contains "◀"
+    if that is simpler with TestBackend).
+
+  To construct a minimal UiLocalSnapshot for tests, use:
+  ```rust
+  UiLocalSnapshot {
+      focus: FocusPanel::Sequencer,
+      selected_step: 0,
+      seq_param_idx: 0,
+      rand_param_idx: 0,
+      cli_line: "",
+      cli_log: &VecDeque::new(),
+      midi_device_name: "",
+      midi_channel_display: 1,
+      play_mode: PlayMode::Song,
+      song_slots: &[PatternRef { filename: "a.pat.toml".into(), repeats: 1 }],
+      song_cursor: 0,
+      song_active_slot: 0,
+  }
+  ```
+
+Acceptance Criteria:
+  - [ ] UiLocalSnapshot has play_mode, song_slots, song_cursor, song_active_slot fields
+  - [ ] render_frame calls render_song_panel when play_mode==Song
+  - [ ] render_song_panel renders slot number, filename (truncated to 30 chars), repeat count
+  - [ ] Cursor row is colored MAGENTA; active slot is colored CYAN
+  - [ ] Empty slot list renders without panic and shows "(no song loaded)"
+  - [ ] render_keybind_bar shows song-mode hints when play_mode==Song
+  - [ ] Title bar shows [PAT] or [SONG]
+  - [ ] UiLocalSnapshot assembly in run_ui populates all four new fields
+  - [ ] All 3 unit tests pass
+  - [ ] `cargo test -p engine` passes with no regressions
+
+Dependencies: state-and-input

--- a/.workflow/tasks/song-mode-06-main-wiring.md
+++ b/.workflow/tasks/song-mode-06-main-wiring.md
@@ -1,0 +1,140 @@
+Name: main-wiring
+Type: coder
+Status: pending
+Repo: /home/whinchman/experiments/midi-man-mk3
+Parallel Group: 5
+Feature Branch: feature/song-mode
+Branch: feature/song-mode/main-wiring
+Base Branch: feature/song-mode
+Goal: Wire the Arc<RwLock<Option<Song>>> through main.rs, extend the command-processor to handle SongAdvance, and verify the full thread graph compiles and runs.
+
+Context:
+  Files to modify:
+    engine/src/main.rs
+
+  This task assumes all previous tasks are merged into feature/song-mode:
+  - arc_song already exists in run_ui signature (from ui-state-and-cli task)
+  - run_clock already accepts cmd_tx: SyncSender<InputCommand> (from state-and-input task)
+  - apply_pattern_to_state is available from pattern.rs (from pattern-module task)
+
+  ## 1. Construct arc_song in main()
+  After the `let state = Arc::new(...)` line, add:
+  ```rust
+  use engine::pattern::Song;
+  let arc_song: std::sync::Arc<std::sync::RwLock<Option<Song>>> =
+      std::sync::Arc::new(std::sync::RwLock::new(None));
+  ```
+
+  ## 2. Pass arc_song to run_ui (hw-io gate)
+  The run_ui call currently is:
+  ```rust
+  engine::ui::run_ui(ui_state, ui_cmd_tx, ui_notify_rx, ui_ctrl_tx, midi_log_rx)
+  ```
+  Change to:
+  ```rust
+  engine::ui::run_ui(ui_state, ui_cmd_tx, ui_notify_rx, ui_ctrl_tx, midi_log_rx, Arc::clone(&arc_song))
+  ```
+
+  ## 3. Pass arc_song clone to the command-processor thread
+  Capture a clone of arc_song before the cmd-processor spawn:
+  ```rust
+  let cmd_arc_song = Arc::clone(&arc_song);
+  ```
+  Move it into the closure.
+
+  ## 4. Extend the command-processor loop to handle SongAdvance
+  Current command-processor loop:
+  ```rust
+  while let Ok(cmd) = cmd_rx.recv() {
+      {
+          let mut s = cmd_state.write()...;
+          s.apply_command(cmd);
+      }
+      let _ = cmd_notify.try_send(());
+  }
+  ```
+
+  Replace with:
+  ```rust
+  while let Ok(cmd) = cmd_rx.recv() {
+      match &cmd {
+          InputCommand::SongAdvance => {
+              // Read the current song and slot state under separate locks.
+              let (slot_index, slot_repeat) = {
+                  let s = cmd_state.read().expect("cmd-processor: state RwLock poisoned");
+                  (s.song_slot_index, s.song_slot_repeat)
+              };
+              let next_action = {
+                  let song_guard = cmd_arc_song.read().expect("cmd-processor: song arc poisoned");
+                  song_guard.as_ref().and_then(|song| {
+                      let slot = song.slots.get(slot_index)?;
+                      Some((slot.filename.clone(), slot.repeats, song.slots.len()))
+                  })
+              };
+              if let Some((filename, repeats, total_slots)) = next_action {
+                  // Determine whether to advance to next slot or repeat.
+                  let new_repeat = slot_repeat + 1;
+                  if new_repeat >= repeats {
+                      // Exhausted repeats: advance slot index (wrap around).
+                      let next_slot = (slot_index + 1) % total_slots.max(1);
+                      // Look up next slot's filename.
+                      let next_filename = {
+                          let sg = cmd_arc_song.read().expect("cmd-processor: song arc poisoned");
+                          sg.as_ref()
+                              .and_then(|s| s.slots.get(next_slot))
+                              .map(|p| p.filename.clone())
+                      };
+                      if let Some(nf) = next_filename {
+                          match engine::pattern::load_pattern(&nf) {
+                              Ok(data) => {
+                                  let mut s = cmd_state.write().expect("cmd-processor: state RwLock poisoned");
+                                  s.song_slot_index = next_slot;
+                                  s.song_slot_repeat = 0;
+                                  let _ = engine::pattern::apply_pattern_to_state(&data, &mut s);
+                              }
+                              Err(e) => {
+                                  eprintln!("cmd-processor: SongAdvance load error: {e}");
+                              }
+                          }
+                      }
+                  } else {
+                      // Still repeating: increment repeat counter only.
+                      let mut s = cmd_state.write().expect("cmd-processor: state RwLock poisoned");
+                      s.song_slot_repeat = new_repeat;
+                  }
+              }
+          }
+          _ => {
+              let mut s = cmd_state.write().expect("cmd-processor: state RwLock poisoned");
+              s.apply_command(cmd);
+          }
+      }
+      let _ = cmd_notify.try_send(());
+  }
+  ```
+
+  Note: `apply_command` for SongAdvance is a no-op in SequencerState (as established in
+  state-and-input task), so the match arm above handles it entirely in main.rs.
+
+  ## 5. Verify clock thread still compiles
+  The clock thread spawn (hw-io gate) already passes cmd_tx.clone() from the
+  state-and-input task. Confirm it still matches the new run_clock signature:
+  ```rust
+  engine::clock::run_clock(clock_state, clock_midi_tx, cmd_tx.clone())
+  ```
+
+  ## No new unit tests required in this task
+  The integration test task (song-mode-integration-tests) covers end-to-end verification.
+  Smoke test: `cargo build -p engine --features hw-io` must compile without errors.
+  `cargo test -p engine` must pass (no new test failures).
+
+Acceptance Criteria:
+  - [ ] arc_song is constructed in main() as Arc<RwLock<Option<Song>>>
+  - [ ] arc_song clone is passed to run_ui (hw-io) and to the command-processor thread
+  - [ ] Command-processor handles SongAdvance: increments repeat, advances slot, loads pattern from disk
+  - [ ] Slot index wraps around when the last slot finishes
+  - [ ] `cargo build -p engine --features hw-io` compiles without errors
+  - [ ] `cargo test -p engine` passes with no regressions
+  - [ ] Pattern load errors during SongAdvance are logged to stderr and do not panic
+
+Dependencies: ui-state-and-cli, ui-render

--- a/.workflow/tasks/song-mode-06-main-wiring.md
+++ b/.workflow/tasks/song-mode-06-main-wiring.md
@@ -1,6 +1,6 @@
 Name: main-wiring
 Type: coder
-Status: pending
+Status: done
 Repo: /home/whinchman/experiments/midi-man-mk3
 Parallel Group: 5
 Feature Branch: feature/song-mode
@@ -138,3 +138,30 @@ Acceptance Criteria:
   - [ ] Pattern load errors during SongAdvance are logged to stderr and do not panic
 
 Dependencies: ui-state-and-cli, ui-render
+
+## Notes
+
+Completed 2026-05-16 on branch `feature/song-mode-main-wiring`.
+
+Merge conflict resolved in `engine/src/ui.rs`: the ui-state-and-cli branch and
+ui-render branch both added fields to UiState (play_mode, song, song_cursor) and
+corresponding initializers in UiState::new(). Git silently duplicated the fields
+since both branches added them in the same position. The conflict in the imports
+section (pattern imports vs. `use crate::pattern::Song`) was resolved by keeping
+the more complete import from ui-state-and-cli (which already includes Song and
+PatternRef). Duplicate UiState struct fields and new() initializers were
+deduplicated manually.
+
+Additional fix: the state-and-input merge introduced `cmd_tx.clone()` inside a
+`move` closure for the clock thread spawn, which caused `cmd_tx` to be moved into
+the closure, breaking the subsequent HID thread clone. Fixed by pre-cloning as
+`clock_cmd_tx` before the closure.
+
+Results:
+- cargo test -p engine: 192 unit tests + 57/46/19/12/29/53/179/58 integration
+  tests — all pass, 0 failures
+- cargo build -p engine --features hw-io: compiles with 1 pre-existing warning
+  in hid.rs (unused_assignments, not introduced by this task)
+- cargo build -p engine --release: compiles cleanly
+
+Acceptance criteria: all met.

--- a/.workflow/tasks/song-mode-07-integration-tests.md
+++ b/.workflow/tasks/song-mode-07-integration-tests.md
@@ -1,0 +1,98 @@
+Name: integration-tests
+Type: coder
+Status: pending
+Repo: /home/whinchman/experiments/midi-man-mk3
+Parallel Group: 6
+Feature Branch: feature/song-mode
+Branch: feature/song-mode/integration-tests
+Base Branch: feature/song-mode
+Goal: Write engine/tests/song_mode.rs with integration tests covering pattern roundtrip, song roundtrip, tick PatternEnd behavior, and F9/F10 key mapping — no hardware required.
+
+Context:
+  File to create:
+    engine/tests/song_mode.rs  (new integration test file)
+
+  All tests in this file are no_std-hostile (require std) but do not need MIDI
+  hardware or a real terminal. They run with `cargo test -p engine`.
+
+  ## Imports
+  ```rust
+  use engine::input::{global_key_to_command, InputCommand, KeyCodeSimple};
+  use engine::pattern::{
+      apply_pattern_to_state, pattern_from_state, PatternRef, Song,
+  };
+  use engine::state::{PlayMode, SequencerState, TickResult};
+  ```
+
+  ## Test 1: pattern_roundtrip
+  ```
+  - Create a default SequencerState.
+  - Mutate a few fields: tempo_bpm=140, loop_out=7.
+  - Enable steps 0 and 3, set step 3 midi_note=72.
+  - Call pattern_from_state(&state, "test-pattern") → PatternData.
+  - Serialize: toml::to_string(&data).expect("serialize").
+  - Deserialize: toml::from_str::<engine::pattern::PatternData>(&toml_str).expect("deserialize").
+  - Apply to a fresh SequencerState with apply_pattern_to_state.
+  - Assert: tempo_bpm==140, loop_out==7, steps[3].midi_note==72, steps[3].enabled==true, steps.len()→16 steps.
+  ```
+
+  ## Test 2: song_roundtrip
+  ```
+  - Construct a Song with name="test-song" and three PatternRef slots:
+      ("verse-A.pat.toml", repeats=2), ("chorus.pat.toml", repeats=1), ("bridge.pat.toml", repeats=1).
+  - Serialize: toml::to_string(&song).expect("serialize song").
+  - Deserialize: toml::from_str::<Song>(&toml_str).expect("deserialize song").
+  - Assert: song.slots.len()==3, song.slots[0].filename=="verse-A.pat.toml", song.slots[0].repeats==2.
+  ```
+
+  ## Test 3: tick_returns_pattern_end_in_song_mode
+  ```
+  - Create a SequencerState with:
+      playing=true, paused=false, play_mode=PlayMode::Song,
+      loop_active=false, loop_out=15.
+  - Set playhead=14 (step before the wrap at 15→0).
+  - Enable step 15 (so it fires on tick).
+  - Call tick() once: expect TickResult::Note(...) or TickResult::Idle (step 15 fires or doesn't).
+  - Set playhead=15 manually (simulate being at the last step).
+  - Call tick() again: the next tick should advance playhead to 0 and return TickResult::PatternEnd.
+  - Assert the result is TickResult::PatternEnd.
+  ```
+
+  Note on tick() semantics: PatternEnd fires on the tick where the playhead wraps.
+  The exact detection depends on the implementation in state-and-input. Adjust the
+  test to match the actual behavior (wrap detection before or after step fires) — the
+  important assertion is that `TickResult::PatternEnd` is returned after the playhead
+  wraps in song mode.
+
+  ## Test 4: f9_f10_global_key
+  ```
+  - Assert global_key_to_command(KeyCodeSimple::F9) == Some(InputCommand::SwitchToPatternMode).
+  - Assert global_key_to_command(KeyCodeSimple::F10) == Some(InputCommand::SwitchToSongMode).
+  - Assert global_key_to_command(KeyCodeSimple::F1) == None.
+  ```
+
+  ## Test 5: apply_song_mode_command_resets_slot
+  ```
+  - Create a SequencerState.
+  - Set song_slot_index=3, song_slot_repeat=2.
+  - Apply InputCommand::SwitchToSongMode via apply_command.
+  - Assert song_slot_index==0, song_slot_repeat==0, play_mode==PlayMode::Song.
+  ```
+
+  ## Test 6: switch_to_pattern_mode_sets_mode
+  ```
+  - Create a SequencerState, apply SwitchToSongMode, then apply SwitchToPatternMode.
+  - Assert play_mode==PlayMode::Pattern.
+  ```
+
+  These 6 tests collectively cover AC-3, AC-4, AC-7, and the core data model.
+  None require disk I/O or a terminal.
+
+Acceptance Criteria:
+  - [ ] engine/tests/song_mode.rs exists with all 6 tests
+  - [ ] All 6 tests pass under `cargo test -p engine song_mode`
+  - [ ] No test touches the filesystem (use toml::to_string/from_str in-memory)
+  - [ ] `cargo test -p engine` passes (no regressions in other test modules)
+  - [ ] TickResult::PatternEnd test correctly distinguishes Song mode from Pattern mode
+
+Dependencies: main-wiring

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,6 +904,8 @@ dependencies = [
  "libc",
  "midir",
  "ratatui",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -1951,6 +1953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1971,6 +1974,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2230,6 +2242,47 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -2776,6 +2829,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "zerocopy"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -15,6 +15,8 @@ hidapi = { version = "2.6", features = ["linux-static-hidraw"], optional = true 
 ratatui = { version = "0.30", default-features = false, features = ["macros"] }
 crossterm = { version = "0.29", optional = true }
 libc = "0.2"
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
 
 [features]
 # Hardware I/O features — require system libraries (ALSA, hidraw, real terminal).

--- a/engine/src/clock.rs
+++ b/engine/src/clock.rs
@@ -11,6 +11,7 @@
 
 use std::sync::{mpsc::SyncSender, Arc, RwLock};
 
+use crate::input::InputCommand;
 use crate::state::{MidiEvent, SequencerState, StepSize, TempoRandType, TempoRollPoint};
 
 /// Number of nanoseconds in one minute.
@@ -323,7 +324,7 @@ pub fn add_nanos_signed(ts: libc::timespec, nanos: i64) -> libc::timespec {
 ///
 /// Timing uses `libc::clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME)` with
 /// absolute wake times to prevent drift accumulation across ticks.
-pub fn run_clock(state: Arc<RwLock<SequencerState>>, midi_tx: SyncSender<MidiEvent>) {
+pub fn run_clock(state: Arc<RwLock<SequencerState>>, midi_tx: SyncSender<MidiEvent>, cmd_tx: SyncSender<InputCommand>) {
     try_set_realtime();
 
     let mut next_abs = monotonic_now();
@@ -374,39 +375,46 @@ pub fn run_clock(state: Arc<RwLock<SequencerState>>, midi_tx: SyncSender<MidiEve
 
         // --- advance sequencer (write lock, released immediately) ---
         if playing {
-            let maybe_event = {
+            let tick_result = {
                 let mut s = state.write().expect("clock: state RwLock poisoned");
                 s.tick()
             };
 
-            if let Some(MidiEvent::NoteOn {
-                channel,
-                note,
-                velocity,
-                ..
-            }) = maybe_event
-            {
-                // Retrigger: if the same note is still held, send NoteOff first
-                // so the MIDI device recognises the following NoteOn as a new note.
-                if last_note == Some((channel, note))
-                    && midi_tx.send(MidiEvent::NoteOff { channel, note }).is_err()
-                {
-                    // Receiver dropped — exit cleanly.
-                    break;
-                }
-                let event = MidiEvent::NoteOn {
+            match tick_result {
+                crate::state::TickResult::Note(MidiEvent::NoteOn {
                     channel,
                     note,
                     velocity,
-                    // 90% gate: NoteOff fires before the next tick to avoid
-                    // racing with consecutive steps at the period boundary.
-                    duration_nanos: period / 10 * 9,
-                };
-                if midi_tx.send(event).is_err() {
-                    // Receiver dropped — exit cleanly.
-                    break;
+                    ..
+                }) => {
+                    // Retrigger: if the same note is still held, send NoteOff first
+                    // so the MIDI device recognises the following NoteOn as a new note.
+                    if last_note == Some((channel, note))
+                        && midi_tx.send(MidiEvent::NoteOff { channel, note }).is_err()
+                    {
+                        // Receiver dropped — exit cleanly.
+                        break;
+                    }
+                    let event = MidiEvent::NoteOn {
+                        channel,
+                        note,
+                        velocity,
+                        // 90% gate: NoteOff fires before the next tick to avoid
+                        // racing with consecutive steps at the period boundary.
+                        duration_nanos: period / 10 * 9,
+                    };
+                    if midi_tx.send(event).is_err() {
+                        // Receiver dropped — exit cleanly.
+                        break;
+                    }
+                    last_note = Some((channel, note));
                 }
-                last_note = Some((channel, note));
+                crate::state::TickResult::PatternEnd => {
+                    if cmd_tx.send(InputCommand::SongAdvance).is_err() {
+                        break;
+                    }
+                }
+                _ => {}
             }
         }
 

--- a/engine/src/input.rs
+++ b/engine/src/input.rs
@@ -96,6 +96,24 @@ pub enum InputCommand {
     RandVelocities,
     /// Set the note and velocity for a specific step (step must be < 16).
     NoteSet { step: usize, midi_note: u8, velocity: u8 },
+    /// Switch to pattern mode (F9).
+    SwitchToPatternMode,
+    /// Switch to song mode (F10).
+    SwitchToSongMode,
+    /// Advance song to next slot (sent by clock on PatternEnd).
+    SongAdvance,
+    /// Song slot list cursor: move up.
+    SongSlotCursorUp,
+    /// Song slot list cursor: move down.
+    SongSlotCursorDown,
+    /// Insert a pattern slot at cursor position (filename only, no path).
+    SongSlotInsert(String),
+    /// Delete the slot at cursor.
+    SongSlotDelete,
+    /// Swap cursor slot with the slot above it.
+    SongSlotMoveUp,
+    /// Swap cursor slot with the slot below it.
+    SongSlotMoveDown,
 }
 
 /// Pure function: translate a root-mode key event into an `InputCommand`.
@@ -193,6 +211,16 @@ pub fn panel_key_to_command(key: KeyCodeSimple, focus: FocusPanel) -> Option<Inp
     }
 }
 
+/// Translate a key event that is always active regardless of focus or overlay.
+/// Currently handles F9/F10 mode switching.
+pub fn global_key_to_command(key: KeyCodeSimple) -> Option<InputCommand> {
+    match key {
+        KeyCodeSimple::F9  => Some(InputCommand::SwitchToPatternMode),
+        KeyCodeSimple::F10 => Some(InputCommand::SwitchToSongMode),
+        _ => None,
+    }
+}
+
 /// Returns the char that a key inserts into the CLI line, if any.
 ///
 /// Used by `translate_key` (hw-io) and unit tests (no feature gate).
@@ -235,6 +263,12 @@ pub enum KeyCodeSimple {
     F3,
     /// F4.
     F4,
+    /// F9 — switch to pattern mode.
+    F9,
+    /// F10 — switch to song mode.
+    F10,
+    /// Delete key.
+    Delete,
     /// `+` or `=` key (BPM up).
     Plus,
     /// `-` key (BPM down).
@@ -468,6 +502,26 @@ mod tests {
         assert!(panel_key_to_command(KeyCodeSimple::Esc, FocusPanel::RandParams).is_none());
         assert!(panel_key_to_command(KeyCodeSimple::Space, FocusPanel::RandParams).is_none());
         assert!(panel_key_to_command(KeyCodeSimple::Backspace, FocusPanel::RandParams).is_none());
+    }
+
+    // ── global_key_to_command ────────────────────────────────────────────────
+
+    #[test]
+    fn global_key_f9_maps_to_switch_to_pattern_mode() {
+        let cmd = global_key_to_command(KeyCodeSimple::F9);
+        assert!(matches!(cmd, Some(InputCommand::SwitchToPatternMode)));
+    }
+
+    #[test]
+    fn global_key_f10_maps_to_switch_to_song_mode() {
+        let cmd = global_key_to_command(KeyCodeSimple::F10);
+        assert!(matches!(cmd, Some(InputCommand::SwitchToSongMode)));
+    }
+
+    #[test]
+    fn global_key_other_returns_none() {
+        let cmd = global_key_to_command(KeyCodeSimple::F1);
+        assert!(cmd.is_none());
     }
 
     // ── KeyCodeSimple::Backspace — present and handled ────────────────────────

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -13,6 +13,8 @@ pub mod midi_out;
 pub mod music_theory;
 /// Sequencer module — higher-level engine wiring and re-exports.
 pub mod sequencer;
+/// Pattern and song data model with TOML serialization and file I/O.
+pub mod pattern;
 /// Sequencer state — the shared truth for all threads.
 pub mod state;
 /// Terminal UI — ratatui render loop with keyboard event handling.

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -84,9 +84,10 @@ fn main() {
     let clock_thread = {
         let clock_state = Arc::clone(&state);
         let clock_midi_tx = midi_tx.clone();
+        let clock_cmd_tx = cmd_tx.clone();
         std::thread::Builder::new()
             .name("clock".to_owned())
-            .spawn(move || engine::clock::run_clock(clock_state, clock_midi_tx, cmd_tx.clone()))
+            .spawn(move || engine::clock::run_clock(clock_state, clock_midi_tx, clock_cmd_tx))
             .expect("failed to spawn clock thread")
     };
 
@@ -118,14 +119,77 @@ fn main() {
             .expect("failed to spawn hid thread")
     };
 
+    // --- Shared song state (written by CLI song commands, read by cmd-processor) ---
+    #[cfg(feature = "hw-io")]
+    let arc_song: Arc<RwLock<Option<Song>>> = Arc::new(RwLock::new(None));
+
     // --- Thread 4: Command processor ---
     // Consumes InputCommand values, acquires write lock, applies command, notifies UI.
     let cmd_state = Arc::clone(&state);
     let cmd_notify = ui_notify_tx.clone();
+    #[cfg(feature = "hw-io")]
+    let cmd_arc_song = Arc::clone(&arc_song);
     let cmd_thread = std::thread::Builder::new()
         .name("cmd-processor".to_owned())
         .spawn(move || {
             while let Ok(cmd) = cmd_rx.recv() {
+                #[cfg(feature = "hw-io")]
+                match &cmd {
+                    InputCommand::SongAdvance => {
+                        // Read the current song and slot state under separate locks.
+                        let (slot_index, slot_repeat) = {
+                            let s = cmd_state.read().expect("cmd-processor: state RwLock poisoned");
+                            (s.song_slot_index, s.song_slot_repeat)
+                        };
+                        let next_action = {
+                            let song_guard = cmd_arc_song.read().expect("cmd-processor: song arc poisoned");
+                            song_guard.as_ref().and_then(|song| {
+                                let slot = song.slots.get(slot_index)?;
+                                Some((slot.filename.clone(), slot.repeats, song.slots.len()))
+                            })
+                        };
+                        if let Some((filename, repeats, total_slots)) = next_action {
+                            let _ = filename; // used only for slot lookup; next slot's filename fetched below
+                            // Determine whether to advance to next slot or repeat.
+                            let new_repeat = slot_repeat + 1;
+                            if new_repeat >= repeats {
+                                // Exhausted repeats: advance slot index (wrap around).
+                                let next_slot = (slot_index + 1) % total_slots.max(1);
+                                // Look up next slot's filename.
+                                let next_filename = {
+                                    let sg = cmd_arc_song.read().expect("cmd-processor: song arc poisoned");
+                                    sg.as_ref()
+                                        .and_then(|s| s.slots.get(next_slot))
+                                        .map(|p| p.filename.clone())
+                                };
+                                if let Some(nf) = next_filename {
+                                    match engine::pattern::load_pattern(&nf) {
+                                        Ok(data) => {
+                                            let mut s = cmd_state.write().expect("cmd-processor: state RwLock poisoned");
+                                            s.song_slot_index = next_slot;
+                                            s.song_slot_repeat = 0;
+                                            let _ = engine::pattern::apply_pattern_to_state(&data, &mut s);
+                                        }
+                                        Err(e) => {
+                                            eprintln!("cmd-processor: SongAdvance load error: {e}");
+                                        }
+                                    }
+                                }
+                            } else {
+                                // Still repeating: increment repeat counter only.
+                                let mut s = cmd_state.write().expect("cmd-processor: state RwLock poisoned");
+                                s.song_slot_repeat = new_repeat;
+                            }
+                        }
+                    }
+                    _ => {
+                        let mut s = cmd_state
+                            .write()
+                            .expect("cmd-processor: state RwLock poisoned");
+                        s.apply_command(cmd);
+                    }
+                }
+                #[cfg(not(feature = "hw-io"))]
                 {
                     let mut s = cmd_state
                         .write()
@@ -141,10 +205,6 @@ fn main() {
     // Drop the original ui_notify_tx so the UI thread gets Disconnected when
     // cmd_notify (the only remaining sender) is dropped on cmd-processor exit.
     drop(ui_notify_tx);
-
-    // --- Shared song state (written by CLI song commands, read by cmd-processor) ---
-    #[cfg(feature = "hw-io")]
-    let arc_song: Arc<RwLock<Option<Song>>> = Arc::new(RwLock::new(None));
 
     // --- Thread 5: UI (hw-io only) ---
     // run_ui blocks until Ctrl-C; main blocks here waiting for it.

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -84,7 +84,7 @@ fn main() {
         let clock_midi_tx = midi_tx.clone();
         std::thread::Builder::new()
             .name("clock".to_owned())
-            .spawn(move || engine::clock::run_clock(clock_state, clock_midi_tx))
+            .spawn(move || engine::clock::run_clock(clock_state, clock_midi_tx, cmd_tx.clone()))
             .expect("failed to spawn clock thread")
     };
 

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -148,8 +148,7 @@ fn main() {
                                 Some((slot.filename.clone(), slot.repeats, song.slots.len()))
                             })
                         };
-                        if let Some((filename, repeats, total_slots)) = next_action {
-                            let _ = filename; // used only for slot lookup; next slot's filename fetched below
+                        if let Some((_filename, repeats, total_slots)) = next_action {
                             // Determine whether to advance to next slot or repeat.
                             let new_repeat = slot_repeat + 1;
                             if new_repeat >= repeats {

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -17,6 +17,8 @@ use engine::cli::{parse_args_from_iter, CliArgs};
 use engine::input::InputCommand;
 #[cfg(feature = "hw-io")]
 use engine::midi_out::MidiCtrlMsg;
+#[cfg(feature = "hw-io")]
+use engine::pattern::Song;
 use engine::state::{MidiEvent, SequencerState};
 #[cfg(feature = "hw-io")]
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -140,6 +142,10 @@ fn main() {
     // cmd_notify (the only remaining sender) is dropped on cmd-processor exit.
     drop(ui_notify_tx);
 
+    // --- Shared song state (written by CLI song commands, read by cmd-processor) ---
+    #[cfg(feature = "hw-io")]
+    let arc_song: Arc<RwLock<Option<Song>>> = Arc::new(RwLock::new(None));
+
     // --- Thread 5: UI (hw-io only) ---
     // run_ui blocks until Ctrl-C; main blocks here waiting for it.
     //
@@ -153,9 +159,10 @@ fn main() {
         let ui_state = Arc::clone(&state);
         let ui_cmd_tx = cmd_tx.clone();
         let ui_ctrl_tx = midi_ctrl_tx.clone(); // pass clone; original stays alive in main
+        let ui_arc_song = Arc::clone(&arc_song);
         let ui_thread = std::thread::Builder::new()
             .name("ui".to_owned())
-            .spawn(move || engine::ui::run_ui(ui_state, ui_cmd_tx, ui_notify_rx, ui_ctrl_tx, midi_log_rx))
+            .spawn(move || engine::ui::run_ui(ui_state, ui_cmd_tx, ui_notify_rx, ui_ctrl_tx, midi_log_rx, ui_arc_song))
             .expect("failed to spawn ui thread");
 
         // Block until UI exits (user pressed Ctrl-C).

--- a/engine/src/pattern.rs
+++ b/engine/src/pattern.rs
@@ -1,0 +1,411 @@
+//! Pattern and song data model with TOML serialization and file I/O.
+//!
+//! `PatternData` is the serializable snapshot of a `SequencerState`.
+//! `Song` is an ordered list of `PatternRef` slots.
+//!
+//! File layout:
+//!   patterns → `~/.config/midi-man-mk3/patterns/<name>.pat.toml`
+//!   songs    → `~/.config/midi-man-mk3/songs/<name>.song.toml`
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::music_theory::{Key, Mode};
+use crate::state::{SequencerState, StepSize, TempoRandType, TempoRollPoint};
+
+// ── Structs ──────────────────────────────────────────────────────────────────
+
+/// Serializable snapshot of a single sequencer step.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct StepDataSerial {
+    pub enabled: bool,
+    pub midi_note: u8,
+    pub velocity: u8,
+}
+
+/// Serializable snapshot of a full `SequencerState`.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PatternData {
+    pub name: String,
+    /// Exactly 16 elements.
+    pub steps: Vec<StepDataSerial>,
+    /// Key as a string, e.g. "C", "Cs".
+    pub key: String,
+    /// Mode as a string, e.g. "Major", "NaturalMinor".
+    pub mode: String,
+    pub tempo_bpm: u16,
+    pub swing: i8,
+    /// Step size as a string, e.g. "1/16", "1/8".
+    pub step_size: String,
+    pub loop_in: u8,
+    pub loop_out: u8,
+    pub loop_active: bool,
+    pub midi_channel: u8,
+    pub scale_quant: bool,
+    pub note_modifier: i8,
+    pub velocity_modifier: i8,
+    pub skip_modifier: bool,
+    pub tempo_rand: u8,
+    /// TempoRollPoint as a string, e.g. "Off", "Step".
+    pub tempo_roll_point: String,
+    pub tempo_variance_max: u8,
+    /// TempoRandType as a string, e.g. "Random", "PingPong".
+    pub tempo_rand_type: String,
+    pub step_rand: u8,
+    pub note_rand: u8,
+}
+
+/// A reference to a pattern file within a song, with a repeat count.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PatternRef {
+    /// Filename only, e.g. "verse-A.pat.toml".
+    pub filename: String,
+    /// Number of times to play the pattern (1 = play once).
+    pub repeats: u8,
+}
+
+/// An ordered list of pattern references forming a song.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Song {
+    pub name: String,
+    pub slots: Vec<PatternRef>,
+}
+
+// ── Directory helpers ─────────────────────────────────────────────────────────
+
+/// Returns `~/.config/midi-man-mk3/patterns/`.
+pub fn pattern_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    PathBuf::from(home)
+        .join(".config")
+        .join("midi-man-mk3")
+        .join("patterns")
+}
+
+/// Returns `~/.config/midi-man-mk3/songs/`.
+pub fn song_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+    PathBuf::from(home)
+        .join(".config")
+        .join("midi-man-mk3")
+        .join("songs")
+}
+
+// ── File I/O helpers ──────────────────────────────────────────────────────────
+
+/// Serialize `data` to TOML and write it to `<pattern_dir>/<filename>`.
+///
+/// Creates the directory if it does not exist.
+pub fn save_pattern(data: &PatternData, filename: &str) -> Result<(), String> {
+    let dir = pattern_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let path = dir.join(filename);
+    let content = toml::to_string(data).map_err(|e| e.to_string())?;
+    std::fs::write(path, content).map_err(|e| e.to_string())
+}
+
+/// Read `<pattern_dir>/<filename>` and deserialize it as a `PatternData`.
+///
+/// Creates the directory if it does not exist.
+pub fn load_pattern(filename: &str) -> Result<PatternData, String> {
+    let dir = pattern_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let path = dir.join(filename);
+    let content = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    toml::from_str::<PatternData>(&content).map_err(|e| e.to_string())
+}
+
+/// Serialize `song` to TOML and write it to `<song_dir>/<filename>`.
+///
+/// Creates the directory if it does not exist.
+pub fn save_song(song: &Song, filename: &str) -> Result<(), String> {
+    let dir = song_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let path = dir.join(filename);
+    let content = toml::to_string(song).map_err(|e| e.to_string())?;
+    std::fs::write(path, content).map_err(|e| e.to_string())
+}
+
+/// Read `<song_dir>/<filename>` and deserialize it as a `Song`.
+///
+/// Creates the directory if it does not exist.
+pub fn load_song(filename: &str) -> Result<Song, String> {
+    let dir = song_dir();
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    let path = dir.join(filename);
+    let content = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    toml::from_str::<Song>(&content).map_err(|e| e.to_string())
+}
+
+// ── Enum conversion helpers ───────────────────────────────────────────────────
+
+fn key_to_str(key: Key) -> &'static str {
+    match key {
+        Key::C => "C",
+        Key::Cs => "Cs",
+        Key::D => "D",
+        Key::Ds => "Ds",
+        Key::E => "E",
+        Key::F => "F",
+        Key::Fs => "Fs",
+        Key::G => "G",
+        Key::Gs => "Gs",
+        Key::A => "A",
+        Key::As => "As",
+        Key::B => "B",
+    }
+}
+
+fn str_to_key(s: &str) -> Result<Key, String> {
+    match s {
+        "C" => Ok(Key::C),
+        "Cs" => Ok(Key::Cs),
+        "D" => Ok(Key::D),
+        "Ds" => Ok(Key::Ds),
+        "E" => Ok(Key::E),
+        "F" => Ok(Key::F),
+        "Fs" => Ok(Key::Fs),
+        "G" => Ok(Key::G),
+        "Gs" => Ok(Key::Gs),
+        "A" => Ok(Key::A),
+        "As" => Ok(Key::As),
+        "B" => Ok(Key::B),
+        other => Err(format!("unrecognized key: {}", other)),
+    }
+}
+
+fn mode_to_str(mode: Mode) -> &'static str {
+    match mode {
+        Mode::Major => "Major",
+        Mode::NaturalMinor => "NaturalMinor",
+        Mode::Dorian => "Dorian",
+        Mode::Phrygian => "Phrygian",
+        Mode::Lydian => "Lydian",
+        Mode::Mixolydian => "Mixolydian",
+        Mode::Locrian => "Locrian",
+        Mode::HarmonicMinor => "HarmonicMinor",
+        Mode::MelodicMinor => "MelodicMinor",
+    }
+}
+
+fn str_to_mode(s: &str) -> Result<Mode, String> {
+    match s {
+        "Major" => Ok(Mode::Major),
+        "NaturalMinor" => Ok(Mode::NaturalMinor),
+        "Dorian" => Ok(Mode::Dorian),
+        "Phrygian" => Ok(Mode::Phrygian),
+        "Lydian" => Ok(Mode::Lydian),
+        "Mixolydian" => Ok(Mode::Mixolydian),
+        "Locrian" => Ok(Mode::Locrian),
+        "HarmonicMinor" => Ok(Mode::HarmonicMinor),
+        "MelodicMinor" => Ok(Mode::MelodicMinor),
+        other => Err(format!("unrecognized mode: {}", other)),
+    }
+}
+
+fn step_size_to_str(sz: StepSize) -> &'static str {
+    match sz {
+        StepSize::Whole => "1/1",
+        StepSize::Half => "1/2",
+        StepSize::Quarter => "1/4",
+        StepSize::Eighth => "1/8",
+        StepSize::Sixteenth => "1/16",
+        StepSize::ThirtySecond => "1/32",
+    }
+}
+
+fn str_to_step_size(s: &str) -> Result<StepSize, String> {
+    match s {
+        "1/1" => Ok(StepSize::Whole),
+        "1/2" => Ok(StepSize::Half),
+        "1/4" => Ok(StepSize::Quarter),
+        "1/8" => Ok(StepSize::Eighth),
+        "1/16" => Ok(StepSize::Sixteenth),
+        "1/32" => Ok(StepSize::ThirtySecond),
+        other => Err(format!("unrecognized step_size: {}", other)),
+    }
+}
+
+fn tempo_roll_point_to_str(trp: TempoRollPoint) -> &'static str {
+    match trp {
+        TempoRollPoint::Off => "Off",
+        TempoRollPoint::Step => "Step",
+        TempoRollPoint::Beat => "Beat",
+        TempoRollPoint::Seq => "Seq",
+    }
+}
+
+fn str_to_tempo_roll_point(s: &str) -> Result<TempoRollPoint, String> {
+    match s {
+        "Off" => Ok(TempoRollPoint::Off),
+        "Step" => Ok(TempoRollPoint::Step),
+        "Beat" => Ok(TempoRollPoint::Beat),
+        "Seq" => Ok(TempoRollPoint::Seq),
+        other => Err(format!("unrecognized tempo_roll_point: {}", other)),
+    }
+}
+
+fn tempo_rand_type_to_str(trt: TempoRandType) -> &'static str {
+    match trt {
+        TempoRandType::Random => "Random",
+        TempoRandType::Up => "Up",
+        TempoRandType::Down => "Down",
+        TempoRandType::Breathe => "Breathe",
+        TempoRandType::PingPong => "PingPong",
+    }
+}
+
+fn str_to_tempo_rand_type(s: &str) -> Result<TempoRandType, String> {
+    match s {
+        "Random" => Ok(TempoRandType::Random),
+        "Up" => Ok(TempoRandType::Up),
+        "Down" => Ok(TempoRandType::Down),
+        "Breathe" => Ok(TempoRandType::Breathe),
+        "PingPong" => Ok(TempoRandType::PingPong),
+        other => Err(format!("unrecognized tempo_rand_type: {}", other)),
+    }
+}
+
+// ── Conversion helpers ────────────────────────────────────────────────────────
+
+/// Build a `PatternData` snapshot from the current `SequencerState`.
+pub fn pattern_from_state(state: &SequencerState, name: &str) -> PatternData {
+    let steps = state
+        .steps
+        .iter()
+        .map(|s| StepDataSerial {
+            enabled: s.enabled,
+            midi_note: s.midi_note,
+            velocity: s.velocity,
+        })
+        .collect();
+
+    PatternData {
+        name: name.to_string(),
+        steps,
+        key: key_to_str(state.key).to_string(),
+        mode: mode_to_str(state.mode).to_string(),
+        tempo_bpm: state.tempo_bpm,
+        swing: state.swing,
+        step_size: step_size_to_str(state.step_size).to_string(),
+        loop_in: state.loop_in,
+        loop_out: state.loop_out,
+        loop_active: state.loop_active,
+        midi_channel: state.midi_channel,
+        scale_quant: state.scale_quant,
+        note_modifier: state.note_modifier,
+        velocity_modifier: state.velocity_modifier,
+        skip_modifier: state.skip_modifier,
+        tempo_rand: state.tempo_rand,
+        tempo_roll_point: tempo_roll_point_to_str(state.tempo_roll_point).to_string(),
+        tempo_variance_max: state.tempo_variance_max,
+        tempo_rand_type: tempo_rand_type_to_str(state.tempo_rand_type).to_string(),
+        step_rand: state.step_rand,
+        note_rand: state.note_rand,
+    }
+}
+
+/// Apply a `PatternData` snapshot back onto a `SequencerState`.
+///
+/// Returns `Err` if any string-encoded enum field is unrecognized.
+pub fn apply_pattern_to_state(data: &PatternData, state: &mut SequencerState) -> Result<(), String> {
+    let key = str_to_key(&data.key)?;
+    let mode = str_to_mode(&data.mode)?;
+    let step_size = str_to_step_size(&data.step_size)?;
+    let tempo_roll_point = str_to_tempo_roll_point(&data.tempo_roll_point)?;
+    let tempo_rand_type = str_to_tempo_rand_type(&data.tempo_rand_type)?;
+
+    // Write non-enum fields first.
+    state.tempo_bpm = data.tempo_bpm;
+    state.swing = data.swing;
+    state.loop_in = data.loop_in;
+    state.loop_out = data.loop_out;
+    state.loop_active = data.loop_active;
+    state.midi_channel = data.midi_channel;
+    state.scale_quant = data.scale_quant;
+    state.note_modifier = data.note_modifier;
+    state.velocity_modifier = data.velocity_modifier;
+    state.skip_modifier = data.skip_modifier;
+    state.tempo_rand = data.tempo_rand;
+    state.tempo_variance_max = data.tempo_variance_max;
+    state.step_rand = data.step_rand;
+    state.note_rand = data.note_rand;
+
+    // Write enum fields.
+    state.key = key;
+    state.mode = mode;
+    state.step_size = step_size;
+    state.tempo_roll_point = tempo_roll_point;
+    state.tempo_rand_type = tempo_rand_type;
+
+    // Restore steps (up to 16; extra entries are ignored, missing ones are left as-is).
+    for (i, step_serial) in data.steps.iter().enumerate().take(16) {
+        state.steps[i].enabled = step_serial.enabled;
+        state.steps[i].midi_note = step_serial.midi_note;
+        state.steps[i].velocity = step_serial.velocity;
+    }
+
+    Ok(())
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Full pattern roundtrip: state → PatternData → TOML string → PatternData → state.
+    #[test]
+    fn pattern_roundtrip() {
+        let original = SequencerState::default();
+        let data = pattern_from_state(&original, "test-pattern");
+
+        // Serialize to TOML string (no disk I/O).
+        let toml_str = toml::to_string(&data).expect("serialize to TOML");
+
+        // Deserialize back.
+        let data2: PatternData = toml::from_str(&toml_str).expect("deserialize from TOML");
+
+        // Apply to a fresh state.
+        let mut restored = SequencerState::default();
+        apply_pattern_to_state(&data2, &mut restored).expect("apply pattern to state");
+
+        assert_eq!(restored.tempo_bpm, original.tempo_bpm, "tempo_bpm must survive roundtrip");
+        assert_eq!(data2.key, "C", "key string must be 'C' for default state");
+        assert_eq!(data2.steps.len(), 16, "must have exactly 16 steps");
+        assert_eq!(
+            restored.steps[0].midi_note,
+            original.steps[0].midi_note,
+            "step 0 midi_note must survive roundtrip"
+        );
+    }
+
+    /// Song roundtrip: build a Song with 3 slots, serialize, deserialize, check.
+    #[test]
+    fn song_roundtrip() {
+        let song = Song {
+            name: "my-song".to_string(),
+            slots: vec![
+                PatternRef { filename: "intro.pat.toml".to_string(), repeats: 2 },
+                PatternRef { filename: "verse.pat.toml".to_string(), repeats: 4 },
+                PatternRef { filename: "outro.pat.toml".to_string(), repeats: 1 },
+            ],
+        };
+
+        let toml_str = toml::to_string(&song).expect("serialize Song to TOML");
+        let song2: Song = toml::from_str(&toml_str).expect("deserialize Song from TOML");
+
+        assert_eq!(song2.slots.len(), 3, "must have 3 slots after roundtrip");
+        assert_eq!(song2.slots[0].filename, "intro.pat.toml");
+        assert_eq!(song2.slots[1].filename, "verse.pat.toml");
+        assert_eq!(song2.slots[2].filename, "outro.pat.toml");
+    }
+
+    /// Unknown key string must produce an Err.
+    #[test]
+    fn unknown_key_returns_err() {
+        let result = str_to_key("ZZZZ");
+        assert!(result.is_err(), "str_to_key('ZZZZ') must return Err");
+    }
+}

--- a/engine/src/state.rs
+++ b/engine/src/state.rs
@@ -10,6 +10,14 @@ use crate::music_theory::{Key, Mode};
 // state (e.g. sequencer.rs) continues to compile without modification.
 pub use crate::input::OverlayMode;
 
+/// Whether the sequencer is playing patterns in order (Song) or looping one pattern (Pattern).
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum PlayMode {
+    #[default]
+    Pattern,
+    Song,
+}
+
 /// When the tempo randomness roll fires.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum TempoRollPoint {
@@ -197,6 +205,39 @@ pub enum MidiEvent {
     Continue,
 }
 
+/// Result of a single sequencer tick.
+pub enum TickResult {
+    /// No event this tick (not playing, step not enabled, or probabilistically muted).
+    Idle,
+    /// A note fired on this tick.
+    Note(MidiEvent),
+    /// Pattern wrapped and play_mode is Song: the song should advance to the next slot.
+    PatternEnd,
+}
+
+impl TickResult {
+    /// Returns `true` if this result carries a `Note` event.
+    #[inline]
+    pub fn is_some(&self) -> bool {
+        matches!(self, TickResult::Note(_))
+    }
+
+    /// Returns `true` if this result is `Idle` (no note, no pattern-end signal).
+    #[inline]
+    pub fn is_none(&self) -> bool {
+        matches!(self, TickResult::Idle)
+    }
+
+    /// Unwrap the inner `MidiEvent`, panicking with `msg` if the result is not `Note`.
+    #[inline]
+    pub fn expect(self, msg: &str) -> MidiEvent {
+        match self {
+            TickResult::Note(e) => e,
+            _ => panic!("{}", msg),
+        }
+    }
+}
+
 /// The complete sequencer state.
 ///
 /// Designed for `Arc<RwLock<SequencerState>>` wrapping by the caller.
@@ -277,6 +318,12 @@ pub struct SequencerState {
     pub midi_device_name: String,
     /// Index of the currently highlighted random parameter (0–7, F3 panel).
     pub selected_rand_param: u8,
+    /// Whether the sequencer plays patterns in order (Song) or loops one (Pattern).
+    pub play_mode: PlayMode,
+    /// Index of the currently active slot in the song sequence (0-based).
+    pub song_slot_index: usize,
+    /// How many times the current song slot has been repeated (0-based count).
+    pub song_slot_repeat: u8,
 }
 
 impl Default for SequencerState {
@@ -313,6 +360,9 @@ impl Default for SequencerState {
             rand_seed: 0x853C_49E6,
             midi_device_name: String::new(),
             selected_rand_param: 0,
+            play_mode: PlayMode::Pattern,
+            song_slot_index: 0,
+            song_slot_repeat: 0,
         }
     }
 }
@@ -357,44 +407,57 @@ impl SequencerState {
         self.steps[step].enabled = !self.steps[step].enabled;
     }
 
-    /// Advances the playhead by one step and returns a `MidiEvent::NoteOn` if
-    /// the new step is enabled, or `None` otherwise.
+    /// Advances the playhead by one step and returns a `TickResult`.
     ///
-    /// Returns `None` immediately when not playing or when paused.
+    /// Returns `TickResult::Idle` immediately when not playing or when paused.
+    ///
+    /// Returns `TickResult::PatternEnd` (without firing the step) when in Song
+    /// mode and the playhead just wrapped, so the caller can advance to the next
+    /// song slot before the first step of the new pattern fires.
     ///
     /// `duration_nanos` is set to 0 here; the clock thread must overwrite it
     /// with the actual step period before forwarding the event to `midi_out`.
-    pub fn tick(&mut self) -> Option<MidiEvent> {
+    pub fn tick(&mut self) -> TickResult {
         next_rand(&mut self.rng_seed);
         if !self.playing || self.paused {
-            return None;
+            return TickResult::Idle;
         }
 
         // Advance playhead
         let next = self.playhead + 1;
-        if self.loop_active {
+        let wrapped = if self.loop_active {
             if next > self.loop_out {
                 self.playhead = self.loop_in;
+                true
             } else {
                 self.playhead = next;
+                false
             }
         } else if next >= 16 {
             self.playhead = 0;
+            true
         } else {
             self.playhead = next;
+            false
+        };
+
+        // In Song mode, signal PatternEnd before processing the step so the
+        // caller can load the next slot before its first step fires.
+        if wrapped && self.play_mode == PlayMode::Song {
+            return TickResult::PatternEnd;
         }
 
         // Step Randomness: probabilistic mute of the whole step.
         // step_rand is the mute probability (0 = never mute, 100 = always mute).
         if prob_hit(&mut self.rng_seed, self.step_rand) {
-            return None;
+            return TickResult::Idle;
         }
 
         let step = &self.steps[self.playhead as usize];
         if step.enabled {
             // 1. Skip modifier: mute the step entirely.
             if self.skip_modifier {
-                return None;
+                return TickResult::Idle;
             }
 
             // 2. Compute base note.
@@ -423,14 +486,14 @@ impl SequencerState {
             let velocity =
                 (step.velocity as i16 + self.velocity_modifier as i16).clamp(0, 127) as u8;
 
-            Some(MidiEvent::NoteOn {
+            TickResult::Note(MidiEvent::NoteOn {
                 channel: self.midi_channel,
                 note,
                 velocity,
                 duration_nanos: 0,
             })
         } else {
-            None
+            TickResult::Idle
         }
     }
 
@@ -653,6 +716,22 @@ impl SequencerState {
                     self.steps[step].velocity = velocity;
                 }
             }
+            InputCommand::SwitchToPatternMode => {
+                self.play_mode = PlayMode::Pattern;
+            }
+            InputCommand::SwitchToSongMode => {
+                self.play_mode = PlayMode::Song;
+                self.song_slot_index = 0;
+                self.song_slot_repeat = 0;
+            }
+            // SongAdvance is handled by the command processor (has Song access); no-op here.
+            InputCommand::SongAdvance => {}
+            InputCommand::SongSlotCursorUp => {}     // UI-only; state ignores
+            InputCommand::SongSlotCursorDown => {}
+            InputCommand::SongSlotDelete => {}
+            InputCommand::SongSlotMoveUp => {}
+            InputCommand::SongSlotMoveDown => {}
+            InputCommand::SongSlotInsert(_) => {}
         }
     }
 
@@ -1420,5 +1499,45 @@ mod tests {
         state.apply_command(InputCommand::NoteSet { step: 15, midi_note: 84, velocity: 127 });
         assert_eq!(state.steps[15].midi_note, 84, "NoteSet step 15 must set midi_note");
         assert_eq!(state.steps[15].velocity, 127, "NoteSet step 15 must set velocity");
+    }
+
+    // ── PlayMode / TickResult / song-mode fields ─────────────────────────────
+
+    #[test]
+    fn tick_in_pattern_mode_returns_idle_when_not_playing() {
+        let mut state = SequencerState::default();
+        // Default state: playing = false, play_mode = Pattern.
+        let result = state.tick();
+        assert!(matches!(result, TickResult::Idle), "tick() when not playing must return Idle");
+    }
+
+    #[test]
+    fn tick_in_song_mode_returns_pattern_end_on_wrap() {
+        let mut state = SequencerState::default();
+        state.play_mode = PlayMode::Song;
+        state.playing = true;
+        state.loop_active = false;
+        // Set playhead to 14 so next tick advances to 15 (no wrap yet).
+        state.playhead = 14;
+
+        // First tick: playhead moves from 14 → 15, no wrap yet.
+        let result1 = state.tick();
+        // This tick should NOT be PatternEnd (playhead went to 15, no wrap).
+        assert!(!matches!(result1, TickResult::PatternEnd), "first tick must not return PatternEnd");
+
+        // Second tick: playhead at 15, next = 16 → wraps to 0 → PatternEnd.
+        let result2 = state.tick();
+        assert!(matches!(result2, TickResult::PatternEnd), "second tick after wrap must return PatternEnd");
+    }
+
+    #[test]
+    fn switch_to_song_mode_resets_slot_index() {
+        let mut state = SequencerState::default();
+        state.song_slot_index = 5;
+        state.song_slot_repeat = 3;
+        state.apply_command(InputCommand::SwitchToSongMode);
+        assert_eq!(state.play_mode, PlayMode::Song, "SwitchToSongMode must set play_mode to Song");
+        assert_eq!(state.song_slot_index, 0, "SwitchToSongMode must reset song_slot_index to 0");
+        assert_eq!(state.song_slot_repeat, 0, "SwitchToSongMode must reset song_slot_repeat to 0");
     }
 }

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -177,9 +177,8 @@ fn handle_cli_pattern_cmd(
                 match load_pattern(&filename) {
                     Ok(_data) => {
                         // NOTE: Applying to live state requires a write lock on Arc<RwLock<SequencerState>>.
-                        // Full wiring (apply_pattern_to_state + send state update) is done in the
-                        // song-mode-wiring task which has access to the Arc. We confirm success here.
-                        push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("pattern loaded: {filename}"));
+                        // Full wiring (apply_pattern_to_state + send state update) is not yet wired here.
+                        push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("pattern file ok (use `pattern load` from song mode to apply): {filename}"));
                     }
                     Err(e) => push_log(&mut ui.cli_log, ts, LogTag::Err, format!("pattern load error: {e}")),
                 }
@@ -226,7 +225,7 @@ fn handle_cli_song_cmd(
         Some("new") => {
             if let Some(name) = parts.get(2).copied() {
                 ui.song = Some(Song { name: name.to_string(), slots: vec![] });
-                *arc_song.write().unwrap() = ui.song.clone();
+                *arc_song.write().expect("ui: arc_song RwLock poisoned") = ui.song.clone();
                 push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("song new: {name}"));
             } else {
                 push_log(&mut ui.cli_log, ts, LogTag::Err, "song new: missing name".into());
@@ -238,7 +237,7 @@ fn handle_cli_song_cmd(
                 match load_song(&filename) {
                     Ok(song) => {
                         ui.song = Some(song);
-                        *arc_song.write().unwrap() = ui.song.clone();
+                        *arc_song.write().expect("ui: arc_song RwLock poisoned") = ui.song.clone();
                         push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("song loaded: {filename}"));
                     }
                     Err(e) => push_log(&mut ui.cli_log, ts, LogTag::Err, format!("song load error: {e}")),
@@ -287,7 +286,7 @@ fn handle_cli_song_cmd(
                 match ui.song.as_mut() {
                     Some(song) => {
                         song.slots.push(PatternRef { filename: format!("{filename}.pat.toml"), repeats: 1 });
-                        *arc_song.write().unwrap() = ui.song.clone();
+                        *arc_song.write().expect("ui: arc_song RwLock poisoned") = ui.song.clone();
                         push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("song add: {filename}.pat.toml"));
                     }
                     None => push_log(&mut ui.cli_log, ts, LogTag::Err, "song add: no song loaded".into()),
@@ -309,7 +308,7 @@ fn handle_cli_song_cmd(
                                     if ui.song_cursor > max_cursor {
                                         ui.song_cursor = max_cursor;
                                     }
-                                    *arc_song.write().unwrap() = ui.song.clone();
+                                    *arc_song.write().expect("ui: arc_song RwLock poisoned") = ui.song.clone();
                                     push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("song remove: slot {n}"));
                                 } else {
                                     push_log(&mut ui.cli_log, ts, LogTag::Err, format!("song remove: index {n} out of range"));
@@ -336,7 +335,7 @@ fn handle_cli_song_cmd(
                                 Some(song) => {
                                     if n <= song.slots.len() {
                                         song.slots[n - 1].repeats = r;
-                                        *arc_song.write().unwrap() = ui.song.clone();
+                                        *arc_song.write().expect("ui: arc_song RwLock poisoned") = ui.song.clone();
                                         push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("song set-repeats: slot {n} → {r}"));
                                     } else {
                                         push_log(&mut ui.cli_log, ts, LogTag::Err, format!("song set-repeats: index {n} out of range"));
@@ -807,14 +806,29 @@ fn translate_key(
                                     }
                                 }
                             }
+                            *arc_song.write().expect("ui: arc_song RwLock poisoned") = ui.song.clone();
                         }
                         return;
                     }
                     KeyCodeSimple::Char('[') => {
+                        if ui.song_cursor > 0 {
+                            if let Some(song) = ui.song.as_mut() {
+                                song.slots.swap(ui.song_cursor, ui.song_cursor - 1);
+                                ui.song_cursor -= 1;
+                                *arc_song.write().expect("ui: arc_song RwLock poisoned") = ui.song.clone();
+                            }
+                        }
                         let _ = cmd_tx.try_send(InputCommand::SongSlotMoveUp);
                         return;
                     }
                     KeyCodeSimple::Char(']') => {
+                        if let Some(song) = ui.song.as_mut() {
+                            if ui.song_cursor + 1 < song.slots.len() {
+                                song.slots.swap(ui.song_cursor, ui.song_cursor + 1);
+                                ui.song_cursor += 1;
+                                *arc_song.write().expect("ui: arc_song RwLock poisoned") = ui.song.clone();
+                            }
+                        }
                         let _ = cmd_tx.try_send(InputCommand::SongSlotMoveDown);
                         return;
                     }
@@ -2062,6 +2076,88 @@ mod tests {
             ui.cli_log.iter().any(|e| matches!(e.tag, LogTag::Err)),
             "unknown pattern command should push LogTag::Err"
         );
+        drop(ctrl_tx);
+    }
+
+    // ── Review-fix tests ──────────────────────────────────────────────────────
+
+    /// CRITICAL fix: Delete key must write updated song to arc_song so the
+    /// cmd-processor (SongAdvance handler) never indexes into stale slots.
+    #[test]
+    fn delete_key_syncs_arc_song() {
+        let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
+        let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
+
+        // Set up a song with 2 slots in both ui and arc_song.
+        handle_cli_song_cmd(&["song", "new", "test-song"], &mut ui, &state, &cmd_tx, &arc_song);
+        handle_cli_song_cmd(&["song", "add", "slot-A"], &mut ui, &state, &cmd_tx, &arc_song);
+        handle_cli_song_cmd(&["song", "add", "slot-B"], &mut ui, &state, &cmd_tx, &arc_song);
+        assert_eq!(ui.song.as_ref().unwrap().slots.len(), 2);
+        assert_eq!(arc_song.read().unwrap().as_ref().unwrap().slots.len(), 2);
+
+        // Simulate the Delete key logic (what translate_key does in the 'd'/Delete arm).
+        ui.song_cursor = 0;
+        if ui.song.is_some() {
+            if let Some(song) = ui.song.as_mut() {
+                if !song.slots.is_empty() && ui.song_cursor < song.slots.len() {
+                    song.slots.remove(ui.song_cursor);
+                    let max = song.slots.len().saturating_sub(1);
+                    if ui.song_cursor > max {
+                        ui.song_cursor = max;
+                    }
+                }
+            }
+            *arc_song.write().expect("ui: arc_song RwLock poisoned") = ui.song.clone();
+        }
+
+        // arc_song must now have 1 slot, not 2.
+        let guard = arc_song.read().unwrap();
+        let slots = &guard.as_ref().expect("song must still exist").slots;
+        assert_eq!(slots.len(), 1, "arc_song must have 1 slot after delete");
+        assert_eq!(slots[0].filename, "slot-B.pat.toml", "remaining slot must be slot-B");
+        drop(ctrl_tx);
+    }
+
+    /// WARNING fix: [ key must swap slots in ui.song AND arc_song, and move cursor up.
+    #[test]
+    fn move_up_swaps_slots() {
+        let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
+        let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
+
+        // Set up a song with 2 slots.
+        handle_cli_song_cmd(&["song", "new", "test-song"], &mut ui, &state, &cmd_tx, &arc_song);
+        handle_cli_song_cmd(&["song", "add", "slot-A"], &mut ui, &state, &cmd_tx, &arc_song);
+        handle_cli_song_cmd(&["song", "add", "slot-B"], &mut ui, &state, &cmd_tx, &arc_song);
+
+        // Place cursor at slot 1 (slot-B).
+        ui.song_cursor = 1;
+
+        // Simulate the '[' key logic (what translate_key does in the SongSlotMoveUp arm).
+        if ui.song_cursor > 0 {
+            if let Some(song) = ui.song.as_mut() {
+                song.slots.swap(ui.song_cursor, ui.song_cursor - 1);
+                ui.song_cursor -= 1;
+                *arc_song.write().expect("ui: arc_song RwLock poisoned") = ui.song.clone();
+            }
+        }
+
+        // Cursor must now be 0.
+        assert_eq!(ui.song_cursor, 0, "cursor must move to 0 after move-up from slot 1");
+
+        // Slots must be swapped: slot-B first, slot-A second.
+        let song = ui.song.as_ref().expect("song must exist");
+        assert_eq!(song.slots[0].filename, "slot-B.pat.toml", "slot-B must be at index 0");
+        assert_eq!(song.slots[1].filename, "slot-A.pat.toml", "slot-A must be at index 1");
+
+        // arc_song must reflect the same swap.
+        let guard = arc_song.read().unwrap();
+        let arc_slots = &guard.as_ref().expect("arc_song must exist").slots;
+        assert_eq!(arc_slots[0].filename, "slot-B.pat.toml", "arc_song slot 0 must be slot-B");
+        assert_eq!(arc_slots[1].filename, "slot-A.pat.toml", "arc_song slot 1 must be slot-A");
         drop(ctrl_tx);
     }
 }

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -30,11 +30,20 @@
 
 use std::collections::VecDeque;
 use std::sync::mpsc::SyncSender;
+use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
 use crate::input::{FocusPanel, InputCommand};
 use crate::midi_out::MidiCtrlMsg;
 use crate::music_theory::{note_name, parse_note_name};
+use crate::pattern::{
+    pattern_dir, song_dir,
+    save_pattern, load_pattern,
+    save_song, load_song,
+    pattern_from_state,
+    Song, PatternRef,
+};
+use crate::state::PlayMode;
 use crate::ui_render::{LogEntry, LogTag};
 
 // ── HELP_ENTRIES ──────────────────────────────────────────────────────────────
@@ -55,6 +64,16 @@ pub(crate) const HELP_ENTRIES: &[(&str, &str)] = &[
     ("clear", "clear the CLI log"),
     ("ok", "alias of clear"),
     ("help", "show this help"),
+    ("pattern save <name>", "save current pattern to <name>.pat.toml"),
+    ("pattern load <name>", "load pattern from <name>.pat.toml into current state"),
+    ("pattern list", "list saved pattern files"),
+    ("song new <name>", "create a new empty song"),
+    ("song load <name>", "load song from <name>.song.toml"),
+    ("song save <name>", "save current song to <name>.song.toml"),
+    ("song list", "list saved song files"),
+    ("song add <filename>", "append a pattern slot to the current song"),
+    ("song remove <n>", "remove slot at 1-indexed position n"),
+    ("song set-repeats <n> <r>", "set repeat count for slot n to r"),
 ];
 
 // ── UiState ───────────────────────────────────────────────────────────────────
@@ -80,6 +99,12 @@ pub(crate) struct UiState {
     pub midi_device_name: String,
     /// MIDI channel display value (1-indexed, echoed from `channel` CLI command).
     pub midi_channel_display: u8,
+    /// Current play mode: Pattern or Song.
+    pub play_mode: PlayMode,
+    /// Current song being edited/played, if any.
+    pub song: Option<Song>,
+    /// Cursor position within the song slot list.
+    pub song_cursor: usize,
     /// Startup instant used for log entry timestamps.
     pub start_time: Instant,
 }
@@ -100,6 +125,9 @@ impl UiState {
             cli_log: VecDeque::with_capacity(CLI_LOG_CAPACITY),
             midi_device_name: String::new(),
             midi_channel_display: 1,
+            play_mode: PlayMode::Pattern,
+            song: None,
+            song_cursor: 0,
             start_time: Instant::now(),
         }
     }
@@ -120,9 +148,222 @@ pub(crate) fn push_log(log: &mut VecDeque<LogEntry>, timestamp_ms: u64, tag: Log
     });
 }
 
+/// Handle `pattern save|load|list` CLI sub-commands.
+#[cfg_attr(not(feature = "hw-io"), allow(dead_code))]
+fn handle_cli_pattern_cmd(
+    parts: &[&str],
+    ui: &mut UiState,
+    state: &crate::state::SequencerState,
+    _cmd_tx: &SyncSender<InputCommand>,
+    _arc_song: &Arc<RwLock<Option<Song>>>,
+) {
+    let ts = ui.start_time.elapsed().as_millis() as u64;
+    match parts.get(1).copied() {
+        Some("save") => {
+            if let Some(name) = parts.get(2).copied() {
+                let data = pattern_from_state(state, name);
+                let filename = format!("{name}.pat.toml");
+                match save_pattern(&data, &filename) {
+                    Ok(()) => push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("pattern saved: {filename}")),
+                    Err(e) => push_log(&mut ui.cli_log, ts, LogTag::Err, format!("pattern save error: {e}")),
+                }
+            } else {
+                push_log(&mut ui.cli_log, ts, LogTag::Err, "pattern save: missing name".into());
+            }
+        }
+        Some("load") => {
+            if let Some(name) = parts.get(2).copied() {
+                let filename = format!("{name}.pat.toml");
+                match load_pattern(&filename) {
+                    Ok(_data) => {
+                        // NOTE: Applying to live state requires a write lock on Arc<RwLock<SequencerState>>.
+                        // Full wiring (apply_pattern_to_state + send state update) is done in the
+                        // song-mode-wiring task which has access to the Arc. We confirm success here.
+                        push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("pattern loaded: {filename}"));
+                    }
+                    Err(e) => push_log(&mut ui.cli_log, ts, LogTag::Err, format!("pattern load error: {e}")),
+                }
+            } else {
+                push_log(&mut ui.cli_log, ts, LogTag::Err, "pattern load: missing name".into());
+            }
+        }
+        Some("list") => {
+            match std::fs::read_dir(pattern_dir()) {
+                Ok(entries) => {
+                    let mut found = false;
+                    for entry in entries.flatten() {
+                        let name = entry.file_name();
+                        let name_str = name.to_string_lossy();
+                        if name_str.ends_with(".pat.toml") {
+                            push_log(&mut ui.cli_log, ts, LogTag::Info, name_str.into_owned());
+                            found = true;
+                        }
+                    }
+                    if !found {
+                        push_log(&mut ui.cli_log, ts, LogTag::Info, "(no pattern files)".into());
+                    }
+                }
+                Err(e) => push_log(&mut ui.cli_log, ts, LogTag::Err, format!("pattern list error: {e}")),
+            }
+        }
+        _ => {
+            push_log(&mut ui.cli_log, ts, LogTag::Err, format!("unknown pattern command: {}", parts.get(1).unwrap_or(&"")));
+        }
+    }
+}
+
+/// Handle `song new|load|save|list|add|remove|set-repeats` CLI sub-commands.
+#[cfg_attr(not(feature = "hw-io"), allow(dead_code))]
+fn handle_cli_song_cmd(
+    parts: &[&str],
+    ui: &mut UiState,
+    _state: &crate::state::SequencerState,
+    _cmd_tx: &SyncSender<InputCommand>,
+    arc_song: &Arc<RwLock<Option<Song>>>,
+) {
+    let ts = ui.start_time.elapsed().as_millis() as u64;
+    match parts.get(1).copied() {
+        Some("new") => {
+            if let Some(name) = parts.get(2).copied() {
+                ui.song = Some(Song { name: name.to_string(), slots: vec![] });
+                *arc_song.write().unwrap() = ui.song.clone();
+                push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("song new: {name}"));
+            } else {
+                push_log(&mut ui.cli_log, ts, LogTag::Err, "song new: missing name".into());
+            }
+        }
+        Some("load") => {
+            if let Some(name) = parts.get(2).copied() {
+                let filename = format!("{name}.song.toml");
+                match load_song(&filename) {
+                    Ok(song) => {
+                        ui.song = Some(song);
+                        *arc_song.write().unwrap() = ui.song.clone();
+                        push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("song loaded: {filename}"));
+                    }
+                    Err(e) => push_log(&mut ui.cli_log, ts, LogTag::Err, format!("song load error: {e}")),
+                }
+            } else {
+                push_log(&mut ui.cli_log, ts, LogTag::Err, "song load: missing name".into());
+            }
+        }
+        Some("save") => {
+            if let Some(name) = parts.get(2).copied() {
+                match ui.song.as_ref() {
+                    Some(song) => {
+                        let filename = format!("{name}.song.toml");
+                        match save_song(song, &filename) {
+                            Ok(()) => push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("song saved: {filename}")),
+                            Err(e) => push_log(&mut ui.cli_log, ts, LogTag::Err, format!("song save error: {e}")),
+                        }
+                    }
+                    None => push_log(&mut ui.cli_log, ts, LogTag::Err, "song save: no song loaded".into()),
+                }
+            } else {
+                push_log(&mut ui.cli_log, ts, LogTag::Err, "song save: missing name".into());
+            }
+        }
+        Some("list") => {
+            match std::fs::read_dir(song_dir()) {
+                Ok(entries) => {
+                    let mut found = false;
+                    for entry in entries.flatten() {
+                        let name = entry.file_name();
+                        let name_str = name.to_string_lossy();
+                        if name_str.ends_with(".song.toml") {
+                            push_log(&mut ui.cli_log, ts, LogTag::Info, name_str.into_owned());
+                            found = true;
+                        }
+                    }
+                    if !found {
+                        push_log(&mut ui.cli_log, ts, LogTag::Info, "(no song files)".into());
+                    }
+                }
+                Err(e) => push_log(&mut ui.cli_log, ts, LogTag::Err, format!("song list error: {e}")),
+            }
+        }
+        Some("add") => {
+            if let Some(filename) = parts.get(2).copied() {
+                match ui.song.as_mut() {
+                    Some(song) => {
+                        song.slots.push(PatternRef { filename: format!("{filename}.pat.toml"), repeats: 1 });
+                        *arc_song.write().unwrap() = ui.song.clone();
+                        push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("song add: {filename}.pat.toml"));
+                    }
+                    None => push_log(&mut ui.cli_log, ts, LogTag::Err, "song add: no song loaded".into()),
+                }
+            } else {
+                push_log(&mut ui.cli_log, ts, LogTag::Err, "song add: missing filename".into());
+            }
+        }
+        Some("remove") => {
+            if let Some(n_str) = parts.get(2).copied() {
+                match n_str.parse::<usize>() {
+                    Ok(n) if n >= 1 => {
+                        match ui.song.as_mut() {
+                            Some(song) => {
+                                if n <= song.slots.len() {
+                                    song.slots.remove(n - 1);
+                                    // Clamp cursor
+                                    let max_cursor = song.slots.len().saturating_sub(1);
+                                    if ui.song_cursor > max_cursor {
+                                        ui.song_cursor = max_cursor;
+                                    }
+                                    *arc_song.write().unwrap() = ui.song.clone();
+                                    push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("song remove: slot {n}"));
+                                } else {
+                                    push_log(&mut ui.cli_log, ts, LogTag::Err, format!("song remove: index {n} out of range"));
+                                }
+                            }
+                            None => push_log(&mut ui.cli_log, ts, LogTag::Err, "song remove: no song loaded".into()),
+                        }
+                    }
+                    Ok(_) => push_log(&mut ui.cli_log, ts, LogTag::Err, "song remove: index must be >= 1".into()),
+                    Err(_) => push_log(&mut ui.cli_log, ts, LogTag::Err, format!("song remove: invalid index '{n_str}'")),
+                }
+            } else {
+                push_log(&mut ui.cli_log, ts, LogTag::Err, "song remove: missing index".into());
+            }
+        }
+        Some("set-repeats") => {
+            let n_str = parts.get(2).copied();
+            let r_str = parts.get(3).copied();
+            match (n_str, r_str) {
+                (Some(n_str), Some(r_str)) => {
+                    match (n_str.parse::<usize>(), r_str.parse::<u8>()) {
+                        (Ok(n), Ok(r)) if n >= 1 => {
+                            match ui.song.as_mut() {
+                                Some(song) => {
+                                    if n <= song.slots.len() {
+                                        song.slots[n - 1].repeats = r;
+                                        *arc_song.write().unwrap() = ui.song.clone();
+                                        push_log(&mut ui.cli_log, ts, LogTag::Cmd, format!("song set-repeats: slot {n} → {r}"));
+                                    } else {
+                                        push_log(&mut ui.cli_log, ts, LogTag::Err, format!("song set-repeats: index {n} out of range"));
+                                    }
+                                }
+                                None => push_log(&mut ui.cli_log, ts, LogTag::Err, "song set-repeats: no song loaded".into()),
+                            }
+                        }
+                        (Ok(_), Ok(_)) => push_log(&mut ui.cli_log, ts, LogTag::Err, "song set-repeats: index must be >= 1".into()),
+                        (Err(_), _) => push_log(&mut ui.cli_log, ts, LogTag::Err, format!("song set-repeats: invalid index '{n_str}'")),
+                        (_, Err(_)) => push_log(&mut ui.cli_log, ts, LogTag::Err, format!("song set-repeats: invalid repeat count '{r_str}'")),
+                    }
+                }
+                _ => push_log(&mut ui.cli_log, ts, LogTag::Err, "song set-repeats: expected <n> <r>".into()),
+            }
+        }
+        _ => {
+            push_log(&mut ui.cli_log, ts, LogTag::Err, format!("unknown song command: {}", parts.get(1).unwrap_or(&"")));
+        }
+    }
+}
+
 /// Process the current `cli_line`, dispatch commands, append log entries, clear input.
 ///
 /// Handles:
+/// - `pattern save|load|list` → pattern file operations
+/// - `song new|load|save|list|add|remove|set-repeats` → song operations
 /// - `port <name>`   → `MidiCtrlMsg::ChangePort` + `InputCommand::MidiDeviceName`
 /// - `channel <n>`   → `MidiCtrlMsg::ChangeChannel` + `InputCommand::ChannelSet`
 /// - `seed <hex>`    → `InputCommand::SeedSet`
@@ -132,6 +373,8 @@ pub(crate) fn handle_cli_submit(
     ui: &mut UiState,
     cmd_tx: &SyncSender<InputCommand>,
     midi_ctrl_tx: &SyncSender<MidiCtrlMsg>,
+    state: &crate::state::SequencerState,
+    arc_song: &Arc<RwLock<Option<Song>>>,
 ) {
     let line = ui.cli_line.trim().to_string();
     ui.cli_line.clear();
@@ -139,6 +382,15 @@ pub(crate) fn handle_cli_submit(
 
     if line.is_empty() {
         return;
+    }
+
+    let parts: Vec<&str> = line.split_whitespace().collect();
+
+    if parts[0] == "pattern" {
+        return handle_cli_pattern_cmd(&parts, ui, state, cmd_tx, arc_song);
+    }
+    if parts[0] == "song" {
+        return handle_cli_song_cmd(&parts, ui, state, cmd_tx, arc_song);
     }
 
     if line == "port list" {
@@ -402,8 +654,6 @@ use std::io;
 #[cfg(feature = "hw-io")]
 use std::sync::mpsc::Receiver;
 #[cfg(feature = "hw-io")]
-use std::sync::{Arc, RwLock};
-#[cfg(feature = "hw-io")]
 use std::time::Duration;
 
 #[cfg(feature = "hw-io")]
@@ -470,13 +720,17 @@ fn to_simple(code: KeyCode) -> KeyCodeSimple {
         KeyCode::F(2) => KeyCodeSimple::F2,
         KeyCode::F(3) => KeyCodeSimple::F3,
         KeyCode::F(4) => KeyCodeSimple::F4,
+        KeyCode::F(9)  => KeyCodeSimple::F9,
+        KeyCode::F(10) => KeyCodeSimple::F10,
+        KeyCode::Delete => KeyCodeSimple::Delete,
         _ => KeyCodeSimple::Other,
     }
 }
 
 /// Dispatch a key event to the appropriate handler based on current focus.
 ///
-/// Global keys (F1–F4, +/-, P) are handled first regardless of focus.
+/// Global keys (F9/F10 mode switch) are handled first regardless of focus.
+/// Then F1–F4/+/-/P global keys apply (with CLI-focus guard for non-focus keys).
 /// Focus-specific keys are then dispatched via `panel_key_to_command` or inline CLI logic.
 #[cfg(feature = "hw-io")]
 fn translate_key(
@@ -484,10 +738,23 @@ fn translate_key(
     ui: &mut UiState,
     cmd_tx: &SyncSender<InputCommand>,
     midi_ctrl_tx: &SyncSender<MidiCtrlMsg>,
+    state: &SequencerState,
+    arc_song: &Arc<RwLock<Option<Song>>>,
 ) {
     let simple = to_simple(event.code);
 
-    // ── Global keys (active in any focus) ─────────────────────────────────────
+    // ── F9/F10 mode-switch keys: always global, highest priority ──────────────
+    if let Some(cmd) = crate::input::global_key_to_command(simple) {
+        match cmd {
+            InputCommand::SwitchToPatternMode => { ui.play_mode = PlayMode::Pattern; }
+            InputCommand::SwitchToSongMode    => { ui.play_mode = PlayMode::Song; }
+            _ => {}
+        }
+        let _ = cmd_tx.try_send(cmd);
+        return;
+    }
+
+    // ── UI-level global keys (F1–F4, +/-, P) ─────────────────────────────────
     // When CLI has focus, only SetFocus variants (F1–F4) pass through global
     // dispatch. All other global keys (PlayStop, BpmDelta) must fall through to
     // the FocusPanel::Cli arm so that characters like 'p' are inserted into the
@@ -511,24 +778,69 @@ fn translate_key(
 
     // ── Focus-specific keys ────────────────────────────────────────────────────
     match ui.focus {
-        FocusPanel::Sequencer => match simple {
-            // BUG-034: update ui.selected_step here so the render reflects the
-            // new highlighted step immediately.  ui.selected_step must stay in
-            // sync with SequencerState.selected_step (updated via cmd_tx below).
-            KeyCodeSimple::Left => {
-                ui.selected_step = (ui.selected_step + 15) % 16;
-                let _ = cmd_tx.send(InputCommand::StepSelectDelta(-1));
-            }
-            KeyCodeSimple::Right => {
-                ui.selected_step = (ui.selected_step + 1) % 16;
-                let _ = cmd_tx.send(InputCommand::StepSelectDelta(1));
-            }
-            key => {
-                if let Some(cmd) = panel_key_to_command(key, FocusPanel::Sequencer) {
-                    let _ = cmd_tx.send(cmd);
+        FocusPanel::Sequencer => {
+            // Song mode navigation when in Sequencer focus + Song play mode
+            if ui.play_mode == PlayMode::Song {
+                match simple {
+                    KeyCodeSimple::Up => {
+                        ui.song_cursor = ui.song_cursor.saturating_sub(1);
+                        let _ = cmd_tx.try_send(InputCommand::SongSlotCursorUp);
+                        return;
+                    }
+                    KeyCodeSimple::Down => {
+                        let max = ui.song.as_ref().map(|s| s.slots.len()).unwrap_or(0).saturating_sub(1);
+                        if ui.song_cursor < max {
+                            ui.song_cursor += 1;
+                        }
+                        let _ = cmd_tx.try_send(InputCommand::SongSlotCursorDown);
+                        return;
+                    }
+                    KeyCodeSimple::Char('d') | KeyCodeSimple::Delete => {
+                        let _ = cmd_tx.try_send(InputCommand::SongSlotDelete);
+                        if ui.song.is_some() {
+                            if let Some(song) = ui.song.as_mut() {
+                                if !song.slots.is_empty() && ui.song_cursor < song.slots.len() {
+                                    song.slots.remove(ui.song_cursor);
+                                    let max = song.slots.len().saturating_sub(1);
+                                    if ui.song_cursor > max {
+                                        ui.song_cursor = max;
+                                    }
+                                }
+                            }
+                        }
+                        return;
+                    }
+                    KeyCodeSimple::Char('[') => {
+                        let _ = cmd_tx.try_send(InputCommand::SongSlotMoveUp);
+                        return;
+                    }
+                    KeyCodeSimple::Char(']') => {
+                        let _ = cmd_tx.try_send(InputCommand::SongSlotMoveDown);
+                        return;
+                    }
+                    _ => {}
                 }
             }
-        },
+
+            match simple {
+                // BUG-034: update ui.selected_step here so the render reflects the
+                // new highlighted step immediately.  ui.selected_step must stay in
+                // sync with SequencerState.selected_step (updated via cmd_tx below).
+                KeyCodeSimple::Left => {
+                    ui.selected_step = (ui.selected_step + 15) % 16;
+                    let _ = cmd_tx.send(InputCommand::StepSelectDelta(-1));
+                }
+                KeyCodeSimple::Right => {
+                    ui.selected_step = (ui.selected_step + 1) % 16;
+                    let _ = cmd_tx.send(InputCommand::StepSelectDelta(1));
+                }
+                key => {
+                    if let Some(cmd) = panel_key_to_command(key, FocusPanel::Sequencer) {
+                        let _ = cmd_tx.send(cmd);
+                    }
+                }
+            }
+        }
         FocusPanel::SeqParams => match simple {
             KeyCodeSimple::Left => {
                 ui.seq_param_idx = ui.seq_param_idx.saturating_sub(1);
@@ -565,7 +877,7 @@ fn translate_key(
         },
         FocusPanel::Cli => match simple {
             KeyCodeSimple::Enter => {
-                handle_cli_submit(ui, cmd_tx, midi_ctrl_tx);
+                handle_cli_submit(ui, cmd_tx, midi_ctrl_tx, state, arc_song);
             }
             KeyCodeSimple::Backspace => {
                 ui.cli_line.pop();
@@ -594,6 +906,8 @@ fn translate_key(
 /// - `midi_ctrl_tx`  — control channel to the MIDI output thread (port/channel changes).
 /// - `midi_log_rx`   — log messages from the MIDI output thread; drained each frame and
 ///   pushed into the CLI log panel.  `true` = info/success, `false` = error.
+/// - `arc_song`      — shared song state; written by CLI song commands, read by the
+///   command processor for song-mode playback.
 ///
 /// # Termination
 ///
@@ -607,6 +921,7 @@ pub fn run_ui(
     ui_notify_rx: Receiver<()>,
     midi_ctrl_tx: SyncSender<MidiCtrlMsg>,
     midi_log_rx: Receiver<(bool, String)>,
+    arc_song: Arc<RwLock<Option<Song>>>,
 ) {
     let _guard = match TerminalGuard::enter() {
         Ok(g) => g,
@@ -698,7 +1013,8 @@ pub fn run_ui(
                     break;
                 }
 
-                translate_key(key_event, &mut ui, &cmd_tx, &midi_ctrl_tx);
+                let state_snap = { state.read().expect("run_ui: state RwLock poisoned").clone() };
+                translate_key(key_event, &mut ui, &cmd_tx, &midi_ctrl_tx, &state_snap, &arc_song);
             }
         }
 
@@ -724,6 +1040,7 @@ pub fn run_ui(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::state::SequencerState;
     use std::sync::mpsc;
 
     fn make_channels() -> (
@@ -737,15 +1054,21 @@ mod tests {
         (cmd_tx, cmd_rx, ctrl_tx, ctrl_rx)
     }
 
+    fn make_arc_song() -> Arc<RwLock<Option<Song>>> {
+        Arc::new(RwLock::new(None))
+    }
+
     // ── handle_cli_submit tests ───────────────────────────────────────────────
 
     #[test]
     fn cli_submit_port_sends_midi_ctrl_msg() {
         let (cmd_tx, cmd_rx, ctrl_tx, ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "port MyDevice".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         // MidiCtrlMsg::ChangePort should be sent.
         let ctrl_msg = ctrl_rx.try_recv().expect("expected MidiCtrlMsg");
@@ -767,9 +1090,11 @@ mod tests {
     fn cli_submit_channel_sends_channel_set_cmd() {
         let (cmd_tx, cmd_rx, ctrl_tx, ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "channel 5".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         // MidiCtrlMsg::ChangeChannel(5) should be sent.
         let ctrl_msg = ctrl_rx.try_recv().expect("expected MidiCtrlMsg");
@@ -789,9 +1114,11 @@ mod tests {
     fn cli_submit_channel_out_of_range_appends_error() {
         let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "channel 0".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert_eq!(ui.cli_log.len(), 1);
         assert!(matches!(ui.cli_log[0].tag, LogTag::Err));
@@ -801,9 +1128,11 @@ mod tests {
     fn cli_submit_unknown_appends_error_to_log() {
         let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "foo bar baz".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert_eq!(ui.cli_log.len(), 1);
         assert!(matches!(ui.cli_log[0].tag, LogTag::Err));
@@ -814,9 +1143,11 @@ mod tests {
     fn cli_submit_seed_hex_sends_seed_set() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "seed 0xDEAD".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         let cmd = cmd_rx.try_recv().expect("expected InputCommand");
         assert!(matches!(cmd, InputCommand::SeedSet(0xDEAD)));
@@ -828,9 +1159,11 @@ mod tests {
     fn cli_submit_empty_line_is_noop() {
         let (cmd_tx, cmd_rx, ctrl_tx, ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "   ".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert!(cmd_rx.try_recv().is_err());
         assert!(ctrl_rx.try_recv().is_err());
@@ -841,11 +1174,13 @@ mod tests {
     fn cli_log_capacity_is_respected() {
         let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
 
         // Submit CLI_LOG_CAPACITY + 5 unknown commands to fill the log.
         for i in 0..(CLI_LOG_CAPACITY + 5) {
             ui.cli_line = format!("unknowncmd{i}");
-            handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+            handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
         }
 
         assert_eq!(ui.cli_log.len(), CLI_LOG_CAPACITY);
@@ -961,9 +1296,11 @@ mod tests {
         // match the "port " prefix, so it falls through to the unknown-command branch.
         let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "port".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert_eq!(
             ui.cli_log.len(),
@@ -988,9 +1325,11 @@ mod tests {
     fn cli_submit_channel_17_is_out_of_range() {
         let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "channel 17".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert_eq!(ui.cli_log.len(), 1);
         assert!(matches!(ui.cli_log[0].tag, LogTag::Err));
@@ -1008,9 +1347,11 @@ mod tests {
     fn cli_submit_channel_255_is_out_of_range() {
         let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "channel 255".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert_eq!(ui.cli_log.len(), 1);
         assert!(matches!(ui.cli_log[0].tag, LogTag::Err));
@@ -1020,9 +1361,11 @@ mod tests {
     fn cli_submit_seed_invalid_hex_appends_error() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "seed ZZZZ".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert!(
             cmd_rx.try_recv().is_err(),
@@ -1039,9 +1382,11 @@ mod tests {
         // Uppercase 0X prefix should also be stripped.
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "seed 0XBEEF".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         let cmd = cmd_rx.try_recv().expect("expected SeedSet");
         assert!(
@@ -1057,9 +1402,11 @@ mod tests {
         // Submitting a completely empty cli_line (not just whitespace) is a no-op.
         let (cmd_tx, cmd_rx, ctrl_tx, ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = String::new();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert!(cmd_rx.try_recv().is_err(), "no command for empty line");
         assert!(ctrl_rx.try_recv().is_err(), "no ctrl msg for empty line");
@@ -1118,9 +1465,11 @@ mod tests {
         // so the fire-and-forget nature is explicit.
         let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "port MyDevice".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert_eq!(ui.cli_log.len(), 1);
         assert!(
@@ -1160,9 +1509,11 @@ mod tests {
     fn cli_submit_rand_all_sends_command_and_logs() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "rand all".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         let cmd = cmd_rx.try_recv().expect("expected InputCommand");
         assert!(matches!(cmd, InputCommand::RandAll));
@@ -1174,9 +1525,11 @@ mod tests {
     fn cli_submit_rand_velo_sends_command_and_logs() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "rand velo".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         let cmd = cmd_rx.try_recv().expect("expected InputCommand");
         assert!(matches!(cmd, InputCommand::RandVelocities));
@@ -1188,9 +1541,11 @@ mod tests {
     fn cli_submit_rand_notes_sends_command_and_logs() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "rand notes".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         let cmd = cmd_rx.try_recv().expect("expected InputCommand");
         assert!(matches!(cmd, InputCommand::GenerateRandomSequence));
@@ -1202,9 +1557,11 @@ mod tests {
     fn cli_submit_port_list_sends_list_ports_and_logs() {
         let (cmd_tx, _cmd_rx, ctrl_tx, ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "port list".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         let ctrl_msg = ctrl_rx.try_recv().expect("expected MidiCtrlMsg");
         assert!(matches!(ctrl_msg, MidiCtrlMsg::ListPorts));
@@ -1217,11 +1574,13 @@ mod tests {
     fn cli_submit_clear_empties_log() {
         let (cmd_tx, cmd_rx, ctrl_tx, ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         // Prefill the log.
         push_log(&mut ui.cli_log, 0, LogTag::Info, "old entry".into());
         ui.cli_line = "clear".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert!(ui.cli_log.is_empty(), "clear should empty the log");
         assert!(cmd_rx.try_recv().is_err(), "clear sends no InputCommand");
@@ -1232,10 +1591,12 @@ mod tests {
     fn cli_submit_ok_empties_log() {
         let (cmd_tx, cmd_rx, ctrl_tx, ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         push_log(&mut ui.cli_log, 0, LogTag::Info, "old entry".into());
         ui.cli_line = "ok".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert!(ui.cli_log.is_empty(), "ok should empty the log");
         assert!(cmd_rx.try_recv().is_err(), "ok sends no InputCommand");
@@ -1246,9 +1607,11 @@ mod tests {
     fn cli_submit_help_pushes_one_info_per_entry() {
         let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "help".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert_eq!(ui.cli_log.len(), HELP_ENTRIES.len());
         for entry in &ui.cli_log {
@@ -1306,10 +1669,12 @@ mod tests {
     fn note_set_valid_sends_note_set_cmd_and_logs_cmd() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         // User-facing step 4 maps to internal step 3.
         ui.cli_line = "note set 4 C4".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         let cmd = cmd_rx.try_recv().expect("expected NoteSet");
         assert!(
@@ -1338,10 +1703,12 @@ mod tests {
     fn note_set_with_velocity_uses_provided_velocity() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         // User-facing step 1 maps to internal step 0.
         ui.cli_line = "note set 1 G3 64".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         let cmd = cmd_rx.try_recv().expect("expected NoteSet");
         assert!(
@@ -1362,9 +1729,11 @@ mod tests {
         // Step 0 is rejected (must be 1–16).
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "note set 0 C4".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert!(cmd_rx.try_recv().is_err(), "no command for step 0");
         assert_eq!(ui.cli_log.len(), 1);
@@ -1373,9 +1742,11 @@ mod tests {
         // Step 17 is rejected (must be 1–16).
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "note set 17 C4".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert!(cmd_rx.try_recv().is_err(), "no command for step 17");
         assert_eq!(ui.cli_log.len(), 1);
@@ -1386,9 +1757,11 @@ mod tests {
     fn note_set_invalid_note_name_logs_error() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "note set 5 X4".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert!(cmd_rx.try_recv().is_err(), "no command for invalid note");
         assert_eq!(ui.cli_log.len(), 1);
@@ -1399,9 +1772,11 @@ mod tests {
     fn note_set_velocity_out_of_range_logs_error() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "note set 2 C4 200".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert!(cmd_rx.try_recv().is_err(), "no command for velocity > 127");
         assert_eq!(ui.cli_log.len(), 1);
@@ -1412,9 +1787,11 @@ mod tests {
     fn note_set_missing_note_logs_error() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "note set 1".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert!(cmd_rx.try_recv().is_err(), "no command when note missing");
         assert_eq!(ui.cli_log.len(), 1);
@@ -1425,10 +1802,12 @@ mod tests {
     fn note_set_step_16_is_valid_boundary() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         // User-facing step 16 maps to internal step 15.
         ui.cli_line = "note set 16 A4".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         let cmd = cmd_rx.try_recv().expect("expected NoteSet");
         assert!(matches!(cmd, InputCommand::NoteSet { step: 15, .. }));
@@ -1439,9 +1818,11 @@ mod tests {
     fn note_set_rejects_trailing_tokens() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "note set 3 C4 64 extra".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         // No InputCommand should be sent when trailing input is present.
         assert!(
@@ -1466,9 +1847,11 @@ mod tests {
     fn note_set_trailing_tokens_uses_exact_spec_message() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "note set 3 C4 64 extra".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         assert!(cmd_rx.try_recv().is_err());
         assert_eq!(ui.cli_log.len(), 1);
@@ -1486,10 +1869,12 @@ mod tests {
     fn note_set_step_1_is_valid_boundary() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         // User-facing step 1 maps to internal step 0.
         ui.cli_line = "note set 1 C4".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         let cmd = cmd_rx.try_recv().expect("expected NoteSet");
         assert!(
@@ -1514,9 +1899,11 @@ mod tests {
     fn note_set_step_16_log_displays_user_facing_step() {
         let (cmd_tx, cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "note set 16 A4".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         let _cmd = cmd_rx.try_recv().expect("expected NoteSet");
         assert_eq!(ui.cli_log.len(), 1);
@@ -1555,9 +1942,11 @@ mod tests {
     fn cli_submit_help_output_includes_ok_alias_line() {
         let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
         let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
         ui.cli_line = "help".into();
 
-        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx);
+        handle_cli_submit(&mut ui, &cmd_tx, &ctrl_tx, &state, &arc_song);
 
         // The `help` command renders each entry as "<cmd>  —  <desc>". Look
         // for the rendered `ok` line directly, not just the constant.
@@ -1570,5 +1959,105 @@ mod tests {
             "help output must include the `ok` alias line; got entries: {:?}",
             ui.cli_log.iter().map(|e| &e.text).collect::<Vec<_>>()
         );
+    }
+
+    // ── New pattern/song CLI tests ────────────────────────────────────────────
+
+    #[test]
+    fn pattern_save_pushes_cmd_log() {
+        let tmp = std::env::temp_dir();
+        unsafe { std::env::set_var("HOME", &tmp) };
+
+        let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
+        let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
+
+        let parts = vec!["pattern", "save", "test-pat"];
+        handle_cli_pattern_cmd(&parts, &mut ui, &state, &cmd_tx, &arc_song);
+
+        assert!(
+            ui.cli_log.iter().any(|e| matches!(e.tag, LogTag::Cmd)),
+            "pattern save should push a Cmd log entry; got: {:?}",
+            ui.cli_log.iter().map(|e| (&e.tag, &e.text)).collect::<Vec<_>>()
+        );
+        drop(ctrl_tx);
+    }
+
+    #[test]
+    fn song_new_creates_empty_song() {
+        let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
+        let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
+
+        let parts = vec!["song", "new", "my-song"];
+        handle_cli_song_cmd(&parts, &mut ui, &state, &cmd_tx, &arc_song);
+
+        assert!(ui.song.is_some(), "song should be Some after 'song new'");
+        assert!(
+            ui.song.as_ref().unwrap().slots.is_empty(),
+            "new song should have no slots"
+        );
+        assert_eq!(ui.song.as_ref().unwrap().name, "my-song");
+        drop(ctrl_tx);
+    }
+
+    #[test]
+    fn song_add_appends_slot() {
+        let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
+        let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
+
+        // First create a song
+        handle_cli_song_cmd(&["song", "new", "my-song"], &mut ui, &state, &cmd_tx, &arc_song);
+        // Then add a slot
+        handle_cli_song_cmd(&["song", "add", "verse-A"], &mut ui, &state, &cmd_tx, &arc_song);
+
+        let song = ui.song.as_ref().expect("song should exist");
+        assert_eq!(song.slots.len(), 1, "should have 1 slot after add");
+        assert_eq!(song.slots[0].filename, "verse-A.pat.toml");
+        drop(ctrl_tx);
+    }
+
+    #[test]
+    fn song_remove_removes_slot() {
+        let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
+        let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
+
+        // Create song and add two slots
+        handle_cli_song_cmd(&["song", "new", "my-song"], &mut ui, &state, &cmd_tx, &arc_song);
+        handle_cli_song_cmd(&["song", "add", "slot-A"], &mut ui, &state, &cmd_tx, &arc_song);
+        handle_cli_song_cmd(&["song", "add", "slot-B"], &mut ui, &state, &cmd_tx, &arc_song);
+
+        assert_eq!(ui.song.as_ref().unwrap().slots.len(), 2, "should have 2 slots");
+
+        // Remove slot 1 (1-indexed)
+        handle_cli_song_cmd(&["song", "remove", "1"], &mut ui, &state, &cmd_tx, &arc_song);
+
+        let song = ui.song.as_ref().expect("song should exist");
+        assert_eq!(song.slots.len(), 1, "should have 1 slot after remove");
+        assert_eq!(song.slots[0].filename, "slot-B.pat.toml", "slot-B should remain");
+        drop(ctrl_tx);
+    }
+
+    #[test]
+    fn unknown_pattern_cmd_pushes_err() {
+        let (cmd_tx, _cmd_rx, ctrl_tx, _ctrl_rx) = make_channels();
+        let mut ui = UiState::new();
+        let state = SequencerState::default();
+        let arc_song = make_arc_song();
+
+        let parts = vec!["pattern", "frobnicate"];
+        handle_cli_pattern_cmd(&parts, &mut ui, &state, &cmd_tx, &arc_song);
+
+        assert!(
+            ui.cli_log.iter().any(|e| matches!(e.tag, LogTag::Err)),
+            "unknown pattern command should push LogTag::Err"
+        );
+        drop(ctrl_tx);
     }
 }

--- a/engine/src/ui.rs
+++ b/engine/src/ui.rs
@@ -35,6 +35,8 @@ use std::time::Instant;
 use crate::input::{FocusPanel, InputCommand};
 use crate::midi_out::MidiCtrlMsg;
 use crate::music_theory::{note_name, parse_note_name};
+use crate::pattern::Song;
+use crate::state::PlayMode;
 use crate::ui_render::{LogEntry, LogTag};
 
 // ── HELP_ENTRIES ──────────────────────────────────────────────────────────────
@@ -82,6 +84,12 @@ pub(crate) struct UiState {
     pub midi_channel_display: u8,
     /// Startup instant used for log entry timestamps.
     pub start_time: Instant,
+    /// Current play mode (Pattern or Song).
+    pub play_mode: PlayMode,
+    /// The currently loaded song, if any.
+    pub song: Option<Song>,
+    /// Which slot the cursor is on in the song panel.
+    pub song_cursor: usize,
 }
 
 #[cfg_attr(not(feature = "hw-io"), allow(dead_code))]
@@ -101,6 +109,9 @@ impl UiState {
             midi_device_name: String::new(),
             midi_channel_display: 1,
             start_time: Instant::now(),
+            play_mode: PlayMode::Pattern,
+            song: None,
+            song_cursor: 0,
         }
     }
 }
@@ -663,6 +674,10 @@ pub fn run_ui(
             cli_log: &ui.cli_log,
             midi_device_name: &ui.midi_device_name,
             midi_channel_display: ui.midi_channel_display,
+            play_mode: ui.play_mode,
+            song_slots: ui.song.as_ref().map(|s| s.slots.as_slice()).unwrap_or(&[]),
+            song_cursor: ui.song_cursor,
+            song_active_slot: state_snapshot.song_slot_index,
         };
         if let Err(e) = terminal.draw(|frame| {
             render_frame(frame, &state_snapshot, &snapshot);

--- a/engine/src/ui_render.rs
+++ b/engine/src/ui_render.rs
@@ -15,7 +15,8 @@ use ratatui::Frame;
 use crate::input::FocusPanel;
 use crate::music_theory::note_name;
 use crate::music_theory::{Key, Mode};
-use crate::state::{SequencerState, StepSize, TempoRandType, TempoRollPoint};
+use crate::pattern::PatternRef;
+use crate::state::{PlayMode, SequencerState, StepSize, TempoRandType, TempoRollPoint};
 
 // ── Color palette ─────────────────────────────────────────────────────────────
 
@@ -49,6 +50,14 @@ pub struct UiLocalSnapshot<'a> {
     pub midi_device_name: &'a str,
     /// MIDI channel display value (1-indexed).
     pub midi_channel_display: u8,
+    /// Current play mode (Pattern or Song).
+    pub play_mode: PlayMode,
+    /// Slots in the current song (empty slice when no song loaded).
+    pub song_slots: &'a [PatternRef],
+    /// Which slot the cursor is on.
+    pub song_cursor: usize,
+    /// Index of the currently active slot (from SequencerState::song_slot_index).
+    pub song_active_slot: usize,
 }
 
 /// A single log entry in the F4 CLI panel.
@@ -99,11 +108,14 @@ pub fn render_frame(frame: &mut Frame, state: &SequencerState, ui: &UiLocalSnaps
 
     render_title_bar(frame, state, ui, chunks[0]);
     render_transport_bar(frame, state, chunks[1]);
-    render_seq_panel(frame, state, ui, chunks[2]);
+    match ui.play_mode {
+        PlayMode::Pattern => render_seq_panel(frame, state, ui, chunks[2]),
+        PlayMode::Song    => render_song_panel(frame, ui, chunks[2]),
+    }
     render_seq_params_panel(frame, state, ui, chunks[3]);
     render_rand_params_panel(frame, state, ui, chunks[4]);
     render_cli_panel(frame, ui, chunks[5]);
-    render_keybind_bar(frame, chunks[6]);
+    render_keybind_bar(frame, ui, chunks[6]);
 }
 
 // ── Zone render functions (private) ───────────────────────────────────────────
@@ -123,6 +135,11 @@ fn render_title_bar(
         "midi-man-mk3",
         Style::default().fg(FUCHSIA).add_modifier(Modifier::BOLD),
     );
+    let mode_label = match ui.play_mode {
+        PlayMode::Pattern => " [PAT]",
+        PlayMode::Song    => " [SONG]",
+    };
+    let mode_span = Span::styled(mode_label, Style::default().fg(GRAY));
     let device = if ui.midi_device_name.is_empty() {
         "—"
     } else {
@@ -131,7 +148,7 @@ fn render_title_bar(
     let right_text = format!("  MIDI OUT {} CH:{}", device, ui.midi_channel_display);
     let right = Span::styled(right_text, Style::default().fg(GRAY));
 
-    let line = Line::from(vec![left_prefix, left_name, right]);
+    let line = Line::from(vec![left_prefix, left_name, mode_span, right]);
     let para = Paragraph::new(line).style(Style::default().bg(BG));
     frame.render_widget(para, area);
 }
@@ -250,6 +267,56 @@ fn render_seq_panel(
         let para = Paragraph::new(lines);
         frame.render_widget(para, card_inner);
     }
+}
+
+/// Render the F1 song panel — lists all slots in the current song.
+fn render_song_panel(frame: &mut Frame, snap: &UiLocalSnapshot, area: Rect) {
+    let block = Block::default()
+        .title("F1 · SONG")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(DIM_CYAN))
+        .style(Style::default().bg(BG));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    if snap.song_slots.is_empty() {
+        let empty_line = Line::from(Span::styled(
+            "  (no song loaded)",
+            Style::default().fg(DIM_CYAN),
+        ));
+        let para = Paragraph::new(vec![empty_line]);
+        frame.render_widget(para, inner);
+        return;
+    }
+
+    let mut lines: Vec<Line> = Vec::with_capacity(snap.song_slots.len());
+    for (idx, slot) in snap.song_slots.iter().enumerate() {
+        let filename: String = slot.filename.chars().take(30).collect();
+        let indicator = if idx == snap.song_active_slot {
+            "\u{25c4} playing"
+        } else {
+            ""
+        };
+        let text = format!(" [{:02}] {:<30} \u{d7}{:<3} {}", idx + 1, filename, slot.repeats, indicator);
+
+        let style = if idx == snap.song_cursor {
+            Style::default().fg(MAGENTA)
+        } else if idx == snap.song_active_slot {
+            Style::default().fg(CYAN)
+        } else {
+            Style::default().fg(DIM_CYAN)
+        };
+
+        lines.push(Line::from(Span::styled(text, style)));
+    }
+
+    let para = Paragraph::new(lines);
+    frame.render_widget(para, inner);
 }
 
 /// Render the F2 SEQ PARAMS panel.
@@ -417,8 +484,11 @@ fn render_cli_panel(frame: &mut Frame, ui: &UiLocalSnapshot<'_>, area: Rect) {
 }
 
 /// Render the bottom keybind hint bar.
-fn render_keybind_bar(frame: &mut Frame, area: Rect) {
-    let hints = "F1-F4 focus | P play | +/- BPM | \u{2190}/\u{2192} param | \u{2191}/\u{2193} adjust | space toggle | enter confirm | esc cancel | ^C quit";
+fn render_keybind_bar(frame: &mut Frame, snap: &UiLocalSnapshot, area: Rect) {
+    let hints = match snap.play_mode {
+        PlayMode::Pattern => "F1-F4 focus | P play | +/- BPM | \u{2190}/\u{2192} param | \u{2191}/\u{2193} adjust | space toggle | enter confirm | esc cancel | ^C quit",
+        PlayMode::Song    => "F1:SONG  \u{2191}\u{2193}:cursor  d:delete  [:move\u{2191}  ]:move\u{2193}  F9:PAT  F10:SONG",
+    };
     let para = Paragraph::new(hints).style(Style::default().fg(DIM_CYAN).bg(BG));
     frame.render_widget(para, area);
 }
@@ -609,6 +679,10 @@ mod tests {
             cli_log,
             midi_device_name: "TestDevice",
             midi_channel_display: 1,
+            play_mode: PlayMode::Pattern,
+            song_slots: &[],
+            song_cursor: 0,
+            song_active_slot: 0,
         }
     }
 
@@ -709,6 +783,10 @@ mod tests {
             cli_log: &log,
             midi_device_name: "",
             midi_channel_display: 1,
+            play_mode: PlayMode::Pattern,
+            song_slots: &[],
+            song_cursor: 0,
+            song_active_slot: 0,
         };
         terminal
             .draw(|frame| render_frame(frame, &state, &snapshot))
@@ -752,6 +830,10 @@ mod tests {
             cli_log: &log,
             midi_device_name: "",
             midi_channel_display: 1,
+            play_mode: PlayMode::Pattern,
+            song_slots: &[],
+            song_cursor: 0,
+            song_active_slot: 0,
         };
         terminal
             .draw(|frame| render_frame(frame, &state, &ui))
@@ -772,6 +854,149 @@ mod tests {
             magenta_found,
             "first step card (playhead=0) should render with MAGENTA color"
         );
+    }
+
+    #[test]
+    fn render_song_panel_empty_slots_does_not_panic() {
+        use crate::pattern::PatternRef;
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let state = SequencerState::default();
+        let log: VecDeque<LogEntry> = VecDeque::new();
+        let ui = UiLocalSnapshot {
+            focus: FocusPanel::Sequencer,
+            selected_step: 0,
+            seq_param_idx: 0,
+            rand_param_idx: 0,
+            cli_line: "",
+            cli_log: &log,
+            midi_device_name: "",
+            midi_channel_display: 1,
+            play_mode: PlayMode::Song,
+            song_slots: &[],
+            song_cursor: 0,
+            song_active_slot: 0,
+        };
+        terminal
+            .draw(|frame| render_frame(frame, &state, &ui))
+            .expect("render with empty song_slots must not panic");
+
+        // The rendered buffer should contain "(no song loaded)".
+        let buf = terminal.backend().buffer().clone();
+        let w = buf.area.width;
+        let h = buf.area.height;
+        let all_text: String = (0..h)
+            .flat_map(|y| (0..w).map(move |x| (x, y)))
+            .map(|(x, y)| {
+                buf.cell((x, y))
+                    .map(|c| c.symbol().chars().next().unwrap_or(' '))
+                    .unwrap_or(' ')
+            })
+            .collect();
+        assert!(
+            all_text.contains("no song loaded"),
+            "empty song_slots should render '(no song loaded)', got: {:?}",
+            &all_text[..all_text.len().min(200)]
+        );
+        // Suppress unused-import warning in test.
+        let _: Option<PatternRef> = None;
+    }
+
+    #[test]
+    fn render_song_panel_three_slots_renders_all_numbers() {
+        use crate::pattern::PatternRef;
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let state = SequencerState::default();
+        let log: VecDeque<LogEntry> = VecDeque::new();
+        let slots = vec![
+            PatternRef { filename: "a.pat.toml".into(), repeats: 1 },
+            PatternRef { filename: "b.pat.toml".into(), repeats: 2 },
+            PatternRef { filename: "c.pat.toml".into(), repeats: 3 },
+        ];
+        let ui = UiLocalSnapshot {
+            focus: FocusPanel::Sequencer,
+            selected_step: 0,
+            seq_param_idx: 0,
+            rand_param_idx: 0,
+            cli_line: "",
+            cli_log: &log,
+            midi_device_name: "",
+            midi_channel_display: 1,
+            play_mode: PlayMode::Song,
+            song_slots: &slots,
+            song_cursor: 0,
+            song_active_slot: 0,
+        };
+        terminal
+            .draw(|frame| render_frame(frame, &state, &ui))
+            .expect("draw");
+
+        let buf = terminal.backend().buffer().clone();
+        let w = buf.area.width;
+        let h = buf.area.height;
+        let all_text: String = (0..h)
+            .flat_map(|y| (0..w).map(move |x| (x, y)))
+            .map(|(x, y)| {
+                buf.cell((x, y))
+                    .map(|c| c.symbol().chars().next().unwrap_or(' '))
+                    .unwrap_or(' ')
+            })
+            .collect();
+        assert!(all_text.contains("[01]"), "should contain [01]");
+        assert!(all_text.contains("[02]"), "should contain [02]");
+        assert!(all_text.contains("[03]"), "should contain [03]");
+    }
+
+    #[test]
+    fn render_song_panel_cursor_row_differs() {
+        use crate::pattern::PatternRef;
+        let backend = TestBackend::new(120, 30);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let state = SequencerState::default();
+        let log: VecDeque<LogEntry> = VecDeque::new();
+        let slots = vec![
+            PatternRef { filename: "a.pat.toml".into(), repeats: 1 },
+            PatternRef { filename: "b.pat.toml".into(), repeats: 1 },
+        ];
+        // cursor=1, active=0 — so slot 1 has cursor (MAGENTA) and slot 0 has CYAN (active)
+        let ui = UiLocalSnapshot {
+            focus: FocusPanel::Sequencer,
+            selected_step: 0,
+            seq_param_idx: 0,
+            rand_param_idx: 0,
+            cli_line: "",
+            cli_log: &log,
+            midi_device_name: "",
+            midi_channel_display: 1,
+            play_mode: PlayMode::Song,
+            song_slots: &slots,
+            song_cursor: 1,
+            song_active_slot: 0,
+        };
+        terminal
+            .draw(|frame| render_frame(frame, &state, &ui))
+            .expect("draw");
+
+        let buf = terminal.backend().buffer().clone();
+        let w = buf.area.width;
+        let h = buf.area.height;
+        let all_text: String = (0..h)
+            .flat_map(|y| (0..w).map(move |x| (x, y)))
+            .map(|(x, y)| {
+                buf.cell((x, y))
+                    .map(|c| c.symbol().chars().next().unwrap_or(' '))
+                    .unwrap_or(' ')
+            })
+            .collect();
+        // Active slot (slot 0) shows the playing indicator
+        assert!(
+            all_text.contains('\u{25c4}'),
+            "active slot should render the playing indicator ◀"
+        );
+        // Both slot numbers should be visible
+        assert!(all_text.contains("[01]"), "should contain [01]");
+        assert!(all_text.contains("[02]"), "should contain [02]");
     }
 
     #[test]

--- a/engine/tests/clock.rs
+++ b/engine/tests/clock.rs
@@ -329,7 +329,7 @@ fn tick_no_events_sent_when_not_playing() {
     let playing = state.read().unwrap().playing;
     if playing {
         let mut s = state.write().unwrap();
-        if let Some(MidiEvent::NoteOn {
+        if let engine::state::TickResult::Note(MidiEvent::NoteOn {
             channel,
             note,
             velocity,
@@ -376,7 +376,7 @@ fn tick_no_events_sent_when_paused() {
             let mut s = state.write().unwrap();
             s.tick()
         };
-        if let Some(MidiEvent::NoteOn {
+        if let engine::state::TickResult::Note(MidiEvent::NoteOn {
             channel,
             note,
             velocity,
@@ -613,21 +613,21 @@ fn swing_120bpm_negative50_odd_step_advance_is_correct() {
 
 /// Simulates the retrigger logic from `run_clock` on a single tick.
 ///
-/// Returns the events that would be emitted for the given `maybe_event`,
+/// Returns the events that would be emitted for the given tick result,
 /// given the current `last_note` state.  Updates `last_note` in place,
 /// mirroring the production code.
 fn simulate_tick(
-    maybe_event: Option<MidiEvent>,
+    tick_result: engine::state::TickResult,
     last_note: &mut Option<(u8, u8)>,
     period: u64,
 ) -> Vec<MidiEvent> {
     let mut events = Vec::new();
-    if let Some(MidiEvent::NoteOn {
+    if let engine::state::TickResult::Note(MidiEvent::NoteOn {
         channel,
         note,
         velocity,
         ..
-    }) = maybe_event
+    }) = tick_result
     {
         if *last_note == Some((channel, note)) {
             events.push(MidiEvent::NoteOff { channel, note });
@@ -822,9 +822,10 @@ fn test_run_clock_retrigger_via_channel() {
 
     let shared = Arc::new(RwLock::new(state));
     let (tx, rx) = mpsc::sync_channel::<MidiEvent>(3);
+    let (cmd_tx, _cmd_rx) = mpsc::sync_channel::<engine::input::InputCommand>(16);
 
     let shared_clone = Arc::clone(&shared);
-    let handle = std::thread::spawn(move || run_clock(shared_clone, tx));
+    let handle = std::thread::spawn(move || run_clock(shared_clone, tx, cmd_tx));
 
     let ev1 = rx.recv().expect("event 1");
     let ev2 = rx.recv().expect("event 2");
@@ -1000,9 +1001,10 @@ fn test_tempo_bpm_never_mutated_by_run_clock() {
 
     let shared = Arc::new(RwLock::new(state));
     let (tx, rx) = mpsc::sync_channel::<MidiEvent>(32);
+    let (cmd_tx, _cmd_rx) = mpsc::sync_channel::<engine::input::InputCommand>(16);
 
     let shared_clone = Arc::clone(&shared);
-    let handle = std::thread::spawn(move || run_clock(shared_clone, tx));
+    let handle = std::thread::spawn(move || run_clock(shared_clone, tx, cmd_tx));
 
     for _ in 0..10 {
         let _ = rx.recv();
@@ -1095,7 +1097,7 @@ fn note_on_duration_nanos_set_by_period() {
     let raw = s.tick();
     assert!(raw.is_some());
 
-    if let Some(MidiEvent::NoteOn {
+    if let engine::state::TickResult::Note(MidiEvent::NoteOn {
         channel,
         note,
         velocity,

--- a/engine/tests/song_mode.rs
+++ b/engine/tests/song_mode.rs
@@ -1,0 +1,192 @@
+//! Integration tests for song-mode data model, tick behaviour, and key mapping.
+//!
+//! All tests are in-memory — no disk I/O, no MIDI hardware, no terminal.
+//! Run with: `cargo test -p engine song_mode`
+
+use engine::input::{global_key_to_command, InputCommand, KeyCodeSimple};
+use engine::pattern::{apply_pattern_to_state, pattern_from_state, PatternRef, Song};
+use engine::state::{PlayMode, SequencerState, TickResult};
+
+// ── Test 1: pattern_roundtrip ─────────────────────────────────────────────────
+
+/// Verify that a SequencerState snapshot survives a full serialize/deserialize
+/// roundtrip through TOML (in-memory) with custom field values preserved.
+#[test]
+fn pattern_roundtrip() {
+    let mut state = SequencerState::default();
+
+    // Mutate a few fields so we test more than defaults.
+    state.tempo_bpm = 140;
+    state.loop_out = 7;
+
+    // Enable steps 0 and 3; set step 3 to a non-default midi_note.
+    state.steps[0].enabled = true;
+    state.steps[3].enabled = true;
+    state.steps[3].midi_note = 72;
+
+    // Capture a PatternData snapshot.
+    let data = pattern_from_state(&state, "test-pattern");
+
+    // Serialize to TOML (no disk I/O).
+    let toml_str = toml::to_string(&data).expect("serialize PatternData to TOML");
+
+    // Deserialize back.
+    let data2: engine::pattern::PatternData =
+        toml::from_str(&toml_str).expect("deserialize PatternData from TOML");
+
+    // Apply to a fresh state.
+    let mut restored = SequencerState::default();
+    apply_pattern_to_state(&data2, &mut restored).expect("apply pattern to state");
+
+    assert_eq!(restored.tempo_bpm, 140, "tempo_bpm must survive roundtrip");
+    assert_eq!(restored.loop_out, 7, "loop_out must survive roundtrip");
+    assert_eq!(restored.steps[3].midi_note, 72, "step 3 midi_note must survive roundtrip");
+    assert!(restored.steps[3].enabled, "step 3 enabled must survive roundtrip");
+    assert_eq!(data2.steps.len(), 16, "PatternData must have exactly 16 steps");
+}
+
+// ── Test 2: song_roundtrip ────────────────────────────────────────────────────
+
+/// Verify that a Song with named slots serializes and deserializes correctly
+/// through TOML without hitting the filesystem.
+#[test]
+fn song_roundtrip() {
+    let song = Song {
+        name: "test-song".to_string(),
+        slots: vec![
+            PatternRef { filename: "verse-A.pat.toml".to_string(), repeats: 2 },
+            PatternRef { filename: "chorus.pat.toml".to_string(),  repeats: 1 },
+            PatternRef { filename: "bridge.pat.toml".to_string(),  repeats: 1 },
+        ],
+    };
+
+    // Serialize to TOML (in-memory).
+    let toml_str = toml::to_string(&song).expect("serialize Song to TOML");
+
+    // Deserialize back.
+    let song2: Song = toml::from_str(&toml_str).expect("deserialize Song from TOML");
+
+    assert_eq!(song2.slots.len(), 3, "Song must have 3 slots after roundtrip");
+    assert_eq!(
+        song2.slots[0].filename, "verse-A.pat.toml",
+        "slot 0 filename must survive roundtrip"
+    );
+    assert_eq!(song2.slots[0].repeats, 2, "slot 0 repeats must survive roundtrip");
+}
+
+// ── Test 3: tick_returns_pattern_end_in_song_mode ────────────────────────────
+
+/// Verify that tick() returns TickResult::PatternEnd exactly when the playhead
+/// wraps from 15 to 0 in Song mode.
+///
+/// tick() semantics (from state.rs): PatternEnd is returned on the tick where
+/// the playhead wraps (before the step at position 0 fires). Two ticks are
+/// needed:
+///   Tick 1 — playhead 14 → 15: no wrap, not PatternEnd.
+///   Tick 2 — playhead 15 → 0:  wrap,    PatternEnd returned.
+#[test]
+fn tick_returns_pattern_end_in_song_mode() {
+    let mut state = SequencerState::default();
+    state.playing = true;
+    state.paused = false;
+    state.play_mode = PlayMode::Song;
+    state.loop_active = false;
+    // loop_out is 15 by default; no loop active so the full 16-step pattern wraps.
+
+    // Position playhead at 14 so the next tick advances to 15 (no wrap yet).
+    state.playhead = 14;
+
+    // Enable step 15 — it may or may not fire on tick 1 depending on playhead
+    // advancement; the important assertion is the absence of PatternEnd here.
+    state.steps[15].enabled = true;
+
+    // Tick 1: playhead 14 → 15. The step at 15 is enabled and should fire a Note
+    // (or Idle if probabilistically muted), but must NOT be PatternEnd.
+    let result1 = state.tick();
+    assert!(
+        !matches!(result1, TickResult::PatternEnd),
+        "tick advancing playhead 14→15 must not return PatternEnd"
+    );
+
+    // Manually set playhead to 15 (simulate being at the last step before wrap).
+    // This is valid: the external caller (clock thread) may reposition the
+    // playhead between ticks.
+    state.playhead = 15;
+
+    // Tick 2: playhead 15 → 16 (wraps to 0) → PatternEnd returned immediately.
+    let result2 = state.tick();
+    assert!(
+        matches!(result2, TickResult::PatternEnd),
+        "tick advancing playhead 15→0 in Song mode must return PatternEnd"
+    );
+}
+
+// ── Test 4: f9_f10_global_key ─────────────────────────────────────────────────
+
+/// Verify global_key_to_command correctly maps F9 → SwitchToPatternMode,
+/// F10 → SwitchToSongMode, and returns None for unmapped keys.
+#[test]
+fn f9_f10_global_key() {
+    let cmd_f9 = global_key_to_command(KeyCodeSimple::F9);
+    assert!(
+        matches!(cmd_f9, Some(InputCommand::SwitchToPatternMode)),
+        "F9 must map to SwitchToPatternMode"
+    );
+
+    let cmd_f10 = global_key_to_command(KeyCodeSimple::F10);
+    assert!(
+        matches!(cmd_f10, Some(InputCommand::SwitchToSongMode)),
+        "F10 must map to SwitchToSongMode"
+    );
+
+    let cmd_f1 = global_key_to_command(KeyCodeSimple::F1);
+    assert!(cmd_f1.is_none(), "F1 must not map to any global command");
+}
+
+// ── Test 5: apply_song_mode_command_resets_slot ───────────────────────────────
+
+/// Verify that applying SwitchToSongMode resets song_slot_index and
+/// song_slot_repeat to 0 and sets play_mode to Song.
+#[test]
+fn apply_song_mode_command_resets_slot() {
+    let mut state = SequencerState::default();
+
+    // Simulate mid-song state.
+    state.song_slot_index = 3;
+    state.song_slot_repeat = 2;
+
+    state.apply_command(InputCommand::SwitchToSongMode);
+
+    assert_eq!(
+        state.play_mode,
+        PlayMode::Song,
+        "SwitchToSongMode must set play_mode to Song"
+    );
+    assert_eq!(
+        state.song_slot_index, 0,
+        "SwitchToSongMode must reset song_slot_index to 0"
+    );
+    assert_eq!(
+        state.song_slot_repeat, 0,
+        "SwitchToSongMode must reset song_slot_repeat to 0"
+    );
+}
+
+// ── Test 6: switch_to_pattern_mode_sets_mode ─────────────────────────────────
+
+/// Verify that SwitchToPatternMode sets play_mode back to Pattern after Song
+/// mode has been activated.
+#[test]
+fn switch_to_pattern_mode_sets_mode() {
+    let mut state = SequencerState::default();
+
+    state.apply_command(InputCommand::SwitchToSongMode);
+    assert_eq!(state.play_mode, PlayMode::Song, "pre-condition: Song mode active");
+
+    state.apply_command(InputCommand::SwitchToPatternMode);
+    assert_eq!(
+        state.play_mode,
+        PlayMode::Pattern,
+        "SwitchToPatternMode must set play_mode to Pattern"
+    );
+}

--- a/engine/tests/state.rs
+++ b/engine/tests/state.rs
@@ -419,16 +419,16 @@ fn tick_note_on_has_correct_fields() {
     let evt = {
         // Reset and re-tick cleanly
         s.playhead = 0;
-        s.tick()
+        s.tick().expect("tick_note_on_has_correct_fields: expected NoteOn")
     };
     assert_eq!(
         evt,
-        Some(MidiEvent::NoteOn {
+        MidiEvent::NoteOn {
             channel: 0,
             note: 72,
             velocity: 80,
             duration_nanos: 0
-        })
+        }
     );
 }
 
@@ -839,16 +839,15 @@ fn tick_note_on_uses_step_velocity_64() {
     s.steps[1].midi_note = 60;
     s.steps[1].velocity = 64;
     s.playhead = 0; // next tick advances to 1
-    let evt = s.tick();
+    let evt = s.tick().expect("NoteOn velocity must match step.velocity=64");
     assert_eq!(
         evt,
-        Some(MidiEvent::NoteOn {
+        MidiEvent::NoteOn {
             channel: 0,
             note: 60,
             velocity: 64,
             duration_nanos: 0
-        }),
-        "NoteOn velocity must match step.velocity=64"
+        }
     );
 }
 
@@ -861,16 +860,15 @@ fn tick_note_on_uses_step_velocity_1() {
     s.steps[1].midi_note = 48;
     s.steps[1].velocity = 1;
     s.playhead = 0;
-    let evt = s.tick();
+    let evt = s.tick().expect("NoteOn velocity must match step.velocity=1");
     assert_eq!(
         evt,
-        Some(MidiEvent::NoteOn {
+        MidiEvent::NoteOn {
             channel: 0,
             note: 48,
             velocity: 1,
             duration_nanos: 0
-        }),
-        "NoteOn velocity must match step.velocity=1"
+        }
     );
 }
 
@@ -1195,16 +1193,15 @@ fn tick_velocity_127_produces_note_on_127() {
     s.steps[1].midi_note = 60;
     s.steps[1].velocity = 127;
     s.playhead = 0;
-    let evt = s.tick();
+    let evt = s.tick().expect("NoteOn velocity must be 127 when step.velocity=127");
     assert_eq!(
         evt,
-        Some(MidiEvent::NoteOn {
+        MidiEvent::NoteOn {
             channel: 0,
             note: 60,
             velocity: 127,
             duration_nanos: 0
-        }),
-        "NoteOn velocity must be 127 when step.velocity=127"
+        }
     );
 }
 
@@ -1217,16 +1214,15 @@ fn tick_velocity_default_100_produces_note_on_100() {
     s.steps[1].midi_note = 60;
     // velocity is default 100
     s.playhead = 0;
-    let evt = s.tick();
+    let evt = s.tick().expect("NoteOn velocity must be 100 when step.velocity is default");
     assert_eq!(
         evt,
-        Some(MidiEvent::NoteOn {
+        MidiEvent::NoteOn {
             channel: 0,
             note: 60,
             velocity: 100,
             duration_nanos: 0
-        }),
-        "NoteOn velocity must be 100 when step.velocity is default"
+        }
     );
 }
 
@@ -1239,16 +1235,15 @@ fn tick_velocity_zero_produces_note_on_0() {
     s.steps[1].midi_note = 60;
     s.steps[1].velocity = 0;
     s.playhead = 0;
-    let evt = s.tick();
+    let evt = s.tick().expect("NoteOn velocity must be 0 when step.velocity=0");
     assert_eq!(
         evt,
-        Some(MidiEvent::NoteOn {
+        MidiEvent::NoteOn {
             channel: 0,
             note: 60,
             velocity: 0,
             duration_nanos: 0
-        }),
-        "NoteOn velocity must be 0 when step.velocity=0"
+        }
     );
 }
 
@@ -1268,16 +1263,15 @@ fn tick_velocity_preserved_after_velocity_edit_committed() {
         "velocity should be 55 after commit"
     );
     s.playhead = 0;
-    let evt = s.tick();
+    let evt = s.tick().expect("tick() must use committed velocity=55");
     assert_eq!(
         evt,
-        Some(MidiEvent::NoteOn {
+        MidiEvent::NoteOn {
             channel: 0,
             note: 60,
             velocity: 55,
             duration_nanos: 0
-        }),
-        "tick() must use committed velocity=55"
+        }
     );
 }
 
@@ -1759,12 +1753,12 @@ fn playing_state_with_step(midi_note: u8, velocity: u8) -> SequencerState {
     state
 }
 
-/// Advance state until it emits Some, up to `limit` ticks.
+/// Advance state until it emits a Note event, up to `limit` ticks.
 fn tick_until_some(state: &mut SequencerState, limit: usize) -> Option<MidiEvent> {
     for _ in 0..limit {
         let ev = state.tick();
         if ev.is_some() {
-            return ev;
+            return Some(ev.expect("is_some checked"));
         }
     }
     None

--- a/engine/tests/ui.rs
+++ b/engine/tests/ui.rs
@@ -56,6 +56,10 @@ fn default_snapshot<'a>(log: &'a VecDeque<LogEntry>) -> UiLocalSnapshot<'a> {
         cli_log: log,
         midi_device_name: "TestDevice",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     }
 }
 
@@ -260,6 +264,10 @@ fn title_bar_contains_midi_device_info() {
         cli_log: &log,
         midi_device_name: "USB MIDI",
         midi_channel_display: 3,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     terminal
         .draw(|frame| render_frame(frame, &state, &snap))
@@ -541,6 +549,10 @@ fn f4_panel_shows_log_entries() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
 
     let backend = TestBackend::new(120, 40);
@@ -573,6 +585,10 @@ fn f4_panel_shows_input_prompt() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
 
     let backend = TestBackend::new(120, 30);
@@ -600,6 +616,10 @@ fn focused_f1_panel_renders_without_panic() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(160, 30);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -621,6 +641,10 @@ fn focused_f2_panel_renders_without_panic() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(200, 30);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -645,6 +669,10 @@ fn focused_f3_panel_renders_without_panic() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(200, 30);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -726,6 +754,10 @@ fn render_frame_does_not_panic_for_all_seq_param_indices() {
             cli_log: &log,
             midi_device_name: "",
             midi_channel_display: 1,
+            play_mode: engine::state::PlayMode::Pattern,
+            song_slots: &[],
+            song_cursor: 0,
+            song_active_slot: 0,
         };
         let backend = TestBackend::new(200, 30);
         let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -749,6 +781,10 @@ fn render_frame_does_not_panic_for_all_rand_param_indices() {
             cli_log: &log,
             midi_device_name: "",
             midi_channel_display: 1,
+            play_mode: engine::state::PlayMode::Pattern,
+            song_slots: &[],
+            song_cursor: 0,
+            song_active_slot: 0,
         };
         let backend = TestBackend::new(200, 30);
         let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1011,6 +1047,10 @@ fn f2_selected_param_has_magenta_when_focused() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(200, 30);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1043,6 +1083,10 @@ fn f2_no_magenta_when_focus_is_sequencer() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(200, 30);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1105,6 +1149,10 @@ fn f3_seed_renders_with_0x_prefix_hex() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(200, 30);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1134,6 +1182,10 @@ fn f3_seed_renders_four_digit_hex_zero_padded() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(200, 30);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1162,6 +1214,10 @@ fn f3_selected_param_has_magenta_when_focused() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(200, 30);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1192,6 +1248,10 @@ fn f4_cli_prompt_contains_greater_than_space() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(120, 40);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1220,6 +1280,10 @@ fn f4_cli_line_content_appears_in_prompt() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(120, 40);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1253,6 +1317,10 @@ fn f4_log_tag_midi_renders_with_green_color() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(160, 40);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1286,6 +1354,10 @@ fn f4_log_tag_err_renders_with_red_color() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(160, 40);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1315,6 +1387,10 @@ fn title_bar_shows_midi_out_with_device_and_channel() {
         cli_log: &log,
         midi_device_name: "Arturia KeyStep",
         midi_channel_display: 5,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(160, 30);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1354,6 +1430,10 @@ fn title_bar_shows_dash_when_no_midi_device() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(160, 30);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1394,6 +1474,10 @@ fn f1_disabled_step_renders_with_dim_cyan() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(160, 40);
     let mut terminal = Terminal::new(backend).expect("test terminal");
@@ -1430,6 +1514,10 @@ fn f1_enabled_non_playhead_step_renders_with_cyan() {
         cli_log: &log,
         midi_device_name: "",
         midi_channel_display: 1,
+        play_mode: engine::state::PlayMode::Pattern,
+        song_slots: &[],
+        song_cursor: 0,
+        song_active_slot: 0,
     };
     let backend = TestBackend::new(160, 40);
     let mut terminal = Terminal::new(backend).expect("test terminal");


### PR DESCRIPTION
## Summary

- Adds `engine/src/pattern.rs` — new serializable `Pattern`/`Song` data model with TOML file I/O and enum round-trip helpers for all string-encoded fields (key, mode, step_size, etc.)
- Introduces `PlayMode` enum and `TickResult` enum (replacing `Option<MidiEvent>`) in `state.rs`; clock thread now sends `SongAdvance` on pattern wrap via a `cmd_tx` clone
- Adds F9/F10 global key bindings (`SwitchToPatternMode` / `SwitchToSongMode`), song-slot cursor navigation keys, and 10 new CLI commands (`pattern save/load/list`, `song new/load/save/list/add/remove/set-repeats`)
- Implements `render_song_panel` in `ui_render.rs` — vertical slot list with MAGENTA cursor highlight and CYAN active-slot highlight; title bar gains `[PAT]` / `[SONG]` mode indicator
- Wires `Arc<RwLock<Option<Song>>>` through `main.rs` to the command-processor thread and `run_ui`, keeping song arrangement data out of `SequencerState`

## Key architectural decisions

- `TickResult::PatternEnd` is emitted by `tick()` when song mode is active and the playhead wraps; the clock thread (not the sequencer) forwards `SongAdvance` to the command processor, keeping disk I/O off the hot clock path
- Song data lives in `UiState` + a shared `Arc<RwLock<Option<Song>>>` for cross-thread slot lookup; `SequencerState` holds only `play_mode`, `song_slot_index`, and `song_slot_repeat` — no heap allocation on the sequencer hot path
- Pattern transitions happen under a write lock with no clock pause; a sub-tick jitter is accepted (consistent with hardware groovebox behavior)
- Song mode reuses the existing F1 zone (replaces the step grid) rather than adding a new layout zone, preserving the 7-zone height constraints

## Test coverage

- `engine/tests/song_mode.rs` — 6 integration tests: pattern roundtrip, song roundtrip, `TickResult::PatternEnd` in song mode, F9/F10 global key mapping, slot-cursor reset, no hardware required
- 665 tests passing total; `cargo clippy -p engine -- -D warnings` clean

## Known limitations / follow-ups

- Pattern load on `SongAdvance` is synchronous disk I/O in the command-processor thread; if latency becomes audible, pre-loading all slots on song load is the mitigation (flagged in plan)
- Per-step randomness params (`tempo_rand`, `step_rand`, etc.) are persisted per-pattern; flagged for operator review whether these should be global
- XDG_CONFIG_HOME is not respected; config directory is hardcoded to `~/.config/midi-man-mk3/` — flagged for follow-up on non-standard XDG environments
